### PR TITLE
argument passing to xacro scripts

### DIFF
--- a/euroc_simulation_server/launch/t3_1.launch
+++ b/euroc_simulation_server/launch/t3_1.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t3_1"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- <arg name="debug" value="true" /> -->
@@ -7,5 +11,8 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t3_1.gazebo.xacro"/>
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
 </launch>

--- a/euroc_simulation_server/launch/t3_2.launch
+++ b/euroc_simulation_server/launch/t3_2.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t3_2"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- <arg name="debug" value="true" /> -->
@@ -7,5 +11,8 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t3_2.gazebo.xacro"/>
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
 </launch>

--- a/euroc_simulation_server/launch/t3_3.launch
+++ b/euroc_simulation_server/launch/t3_3.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t3_3"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- <arg name="debug" value="true" /> -->
@@ -7,5 +11,8 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t3_3.gazebo.xacro"/>
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
 </launch>

--- a/euroc_simulation_server/launch/t4_1.launch
+++ b/euroc_simulation_server/launch/t4_1.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t4_1"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- arg name="debug" value="true" / -->
@@ -8,6 +12,9 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t4_1.gazebo.xacro" />
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
   
   <group ns="firefly">

--- a/euroc_simulation_server/launch/t4_2.launch
+++ b/euroc_simulation_server/launch/t4_2.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t4_2"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- arg name="debug" value="true" / -->
@@ -8,6 +12,9 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t4_2.gazebo.xacro" />
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
   
   <group ns="firefly">

--- a/euroc_simulation_server/launch/t4_3.launch
+++ b/euroc_simulation_server/launch/t4_3.launch
@@ -1,4 +1,8 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="euroc_c3_t4_3"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- arg name="debug" value="true" / -->
@@ -8,6 +12,9 @@
 
   <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
     <arg name="model" value="$(find euroc_simulation_server)/urdf/firefly_t4_2.gazebo.xacro" />
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
   </include>
   
   <group ns="firefly">

--- a/euroc_simulation_server/urdf/firefly_base.urdf.xacro
+++ b/euroc_simulation_server/urdf/firefly_base.urdf.xacro
@@ -2,7 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <!-- Instantiate firefly "mechanics" -->
-  <xacro:property name="enable_ground_truth" value="true"/>
   <xacro:include filename="$(find mav_description)/urdf/firefly.urdf.xacro" />
 
   <!-- Create link and joint for a sensor -->
@@ -45,7 +44,7 @@
   </gazebo>
 
   <!-- Ground truth IMU Data. Will be removed for final evaluation. -->
-  <xacro:if value="${enable_ground_truth}">
+  <xacro:if value="$(arg enable_ground_truth)">
     <gazebo>
       <plugin filename="libhector_gazebo_ros_imu.so" name="imu_ros">
         <robotNamespace>${namespace}</robotNamespace>
@@ -74,7 +73,7 @@
   </gazebo>
 
   <!-- Mount a generic pose sensor providing ground truth. Will be removed for final evaluation. -->
-  <xacro:if value="${enable_ground_truth}">
+  <xacro:if value="$(arg enable_ground_truth)">
     <gazebo>
       <!-- Generic 6D pose sensor plugin -->
       <plugin filename="libmav_gazebo_pose_plugin.so" name="pose_sensor1">
@@ -95,10 +94,10 @@
   <!-- Instantiate a logger -->
   <gazebo>
     <!-- ROS Bag Plugin -->
-    <xacro:if value="${enable_bag_plugin}">
+    <xacro:if value="$(arg enable_logging)">
       <plugin filename="libmav_gazebo_bag_plugin.so" name="rosbag">
         <robotNamespace>${namespace}</robotNamespace>
-        <bagFileName>${bag_file}</bagFileName>
+        <bagFileName>$(arg log_file)</bagFileName>
         <linkName>base_link</linkName>
         <frameId>base_link</frameId>
         <controlAttitudeThrustSubTopic>mav_cmd</controlAttitudeThrustSubTopic>

--- a/euroc_simulation_server/urdf/firefly_t3_1.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t3_1.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t3_1.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/euroc_simulation_server/urdf/firefly_t3_2.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t3_2.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t3_2.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/euroc_simulation_server/urdf/firefly_t3_3.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t3_3.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t3_3.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/euroc_simulation_server/urdf/firefly_t4_1.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t4_1.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t4_1.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/euroc_simulation_server/urdf/firefly_t4_2.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t4_2.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t4_2.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/euroc_simulation_server/urdf/firefly_t4_3.gazebo.xacro
+++ b/euroc_simulation_server/urdf/firefly_t4_3.gazebo.xacro
@@ -2,8 +2,6 @@
 
 <robot name="firefly" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="namespace" value="firefly" />
-  <xacro:property name="enable_bag_plugin" value="true" />
-  <xacro:property name="bag_file" value="firefly_t4_3.bag" />
 
   <!-- Instantiate default firefly-->
   <xacro:include filename="$(find euroc_simulation_server)/urdf/firefly_base.urdf.xacro" />

--- a/mav_description/urdf/firefly.gazebo.xacro
+++ b/mav_description/urdf/firefly.gazebo.xacro
@@ -81,10 +81,10 @@
   <!-- Instantiate a logger -->
   <gazebo>
     <!-- ROS Bag Plugin -->
-    <xacro:if value="${enable_bag_plugin}">
+    <xacro:if value="$(arg enable_logging)">
       <plugin filename="libmav_gazebo_bag_plugin.so" name="rosbag">
         <robotNamespace>${namespace}</robotNamespace>
-        <bagFileName>${bag_file}</bagFileName>
+        <bagFileName>$(arg log_file)</bagFileName>
         <linkName>base_link</linkName>
         <frameId>base_link</frameId>
         <controlAttitudeThrustSubTopic>mav_cmd</controlAttitudeThrustSubTopic>

--- a/mav_gazebo/launch/firefly_city_world.launch
+++ b/mav_gazebo/launch/firefly_city_world.launch
@@ -1,8 +1,16 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="firefly"/>
+
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/test_city.world"/>
     <!-- <arg name="debug" value="true" /> -->
   </include>
-  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch" />
+  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
+  </include>
   <!--node name="gazebo_pose_publisher" pkg="mav_gazebo" type="gazebo_pose_publisher" args="firefly /firefly/pose"/-->
 </launch>

--- a/mav_gazebo/launch/firefly_empty_world.launch
+++ b/mav_gazebo/launch/firefly_empty_world.launch
@@ -1,8 +1,16 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="firefly"/>
+  
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/basic.world"/>
     <!-- <arg name="debug" value="true" /> -->
   </include>
-  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch" />
+  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
+  </include>
   <!--node name="gazebo_pose_publisher" pkg="mav_gazebo" type="gazebo_pose_publisher" args="firefly /firefly/pose"/-->
 </launch>

--- a/mav_gazebo/launch/firefly_waypoint_world.launch
+++ b/mav_gazebo/launch/firefly_waypoint_world.launch
@@ -1,9 +1,17 @@
 <launch>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="firefly"/>
+
   <env name="GAZEBO_MODEL_PATH" value="$(find mav_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find mav_gazebo)/worlds/waypoint.world"/>
     <!-- <arg name="debug" value="true" /> -->
   </include>
-  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch" />
+  <include file="$(find mav_gazebo)/launch/spawn_firefly.launch">
+    <arg name="enable_logging" value="$(arg enable_logging)" />
+    <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="log_file" value="$(arg log_file)"/>
+  </include>
   <!--node name="gazebo_pose_publisher" pkg="mav_gazebo" type="gazebo_pose_publisher" args="firefly /firefly/pose"/-->
 </launch>

--- a/mav_gazebo/launch/spawn_firefly.launch
+++ b/mav_gazebo/launch/spawn_firefly.launch
@@ -7,9 +7,17 @@
   <arg name="x" default="0.0"/>
   <arg name="y" default="0.0"/>
   <arg name="z" default="0.08"/>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="firefly"/>
 
   <!-- send the robot XML to param server -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)'" />
+  <param name="robot_description" command="
+    $(find xacro)/xacro.py '$(arg model)' 
+    enable_logging:=$(arg enable_logging) 
+    enable_ground_truth:=$(arg enable_ground_truth)
+    log_file:=$(arg log_file)"
+  />
   <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />
 
   <!-- push robot_description to factory and spawn robot in gazebo -->


### PR DESCRIPTION
firefly xacro files now expect the following parameters that can be passed via launch files:
- enable_ground_truth: enables groundtruth plugins. true by default
- enable_logging: enables logging_plugin. false by default
- log_file: specifies a logfile. ~/.ros/firefly_DATE.bag by default
