### PR TITLE
mav_gazebo_plugins: fixed wrong sdf params for motor_velocity_reference

### DIFF
--- a/euroc_simulation_server/urdf/firefly_base.urdf.xacro
+++ b/euroc_simulation_server/urdf/firefly_base.urdf.xacro
@@ -63,7 +63,7 @@
       <commandMotorSpeedSubTopic>command/motors</commandMotorSpeedSubTopic>
       <imuSubTopic>imu</imuSubTopic>
       <poseTopic>pose</poseTopic>
-      <motorVelocityReferenceTopic>motor_velocity_reference</motorVelocityReferenceTopic>
+      <motorVelocityCommandPubTopic>motor_velocity_reference</motorVelocityCommandPubTopic>
     </plugin>
   </gazebo>
 

--- a/mav_description/urdf/component_snippets.xacro
+++ b/mav_description/urdf/component_snippets.xacro
@@ -23,7 +23,7 @@
     <commandMotorSpeedSubTopic>command/motors</commandMotorSpeedSubTopic>
     <imuSubTopic>imu</imuSubTopic>
     <poseTopic>pose</poseTopic>
-    <motorVelocityReferenceTopic>motor_velocity_reference</motorVelocityReferenceTopic>
+    <motorVelocityCommandPubTopic>motor_velocity_reference</motorVelocityCommandPubTopic>
   </plugin>
 </gazebo>
 

--- a/mav_description/urdf/firefly.gazebo.xacro
+++ b/mav_description/urdf/firefly.gazebo.xacro
@@ -41,7 +41,7 @@
       <accelerometerTurnOnBiasSigma>0.1960</accelerometerTurnOnBiasSigma> <!-- Accelerometer turn on bias standard deviation [m/s^2] -->
     </plugin>
   </gazebo>
-  
+
   <!-- Instantiate a controller -->
   <gazebo>
     <!-- Controller interface -->
@@ -52,7 +52,7 @@
       <commandMotorSpeedSubTopic>command/motors</commandMotorSpeedSubTopic>
       <imuSubTopic>imu</imuSubTopic>
       <poseTopic>pose</poseTopic>
-      <motorVelocityReferenceTopic>motor_velocity_reference</motorVelocityReferenceTopic>
+      <motorVelocityCommandPubTopic>motor_velocity_reference</motorVelocityCommandPubTopic>
     </plugin>
   </gazebo>
 

--- a/mav_description/urdf/firefly.urdf.xacro
+++ b/mav_description/urdf/firefly.urdf.xacro
@@ -25,13 +25,13 @@
   <xacro:property name="body_inertia">
     <inertia ixx="0.0347563" ixy="0.0" ixz="0.0" iyy="0.0458929" iyz="0.0" izz="0.0977" /> <!-- [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] -->
   </xacro:property>
-  
+
   <!-- inertia of a single rotor, assuming it is a cuboid. Height=3mm, width=15mm -->
   <xacro:property name="rotor_inertia">
-    <inertia 
-    ixx="${1/12 * mass_rotor * (0.015 * 0.015 + 0.003 * 0.003) * rotor_velocity_slowdown_sim}" 
-    iyy="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.003 * 0.003) * rotor_velocity_slowdown_sim}" 
-    izz="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.015 * 0.015) * rotor_velocity_slowdown_sim}" 
+    <inertia
+    ixx="${1/12 * mass_rotor * (0.015 * 0.015 + 0.003 * 0.003) * rotor_velocity_slowdown_sim}"
+    iyy="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.003 * 0.003) * rotor_velocity_slowdown_sim}"
+    izz="${1/12 * mass_rotor * (4 * radius_rotor * radius_rotor + 0.015 * 0.015) * rotor_velocity_slowdown_sim}"
     ixy="0.0" ixz="0.0"  iyz="0.0" /> <!-- [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] [kg·m^2] -->
   </xacro:property>
 

--- a/mav_description/urdf/multirotor_base.urdf.xacro
+++ b/mav_description/urdf/multirotor_base.urdf.xacro
@@ -54,7 +54,7 @@
     <!-- attach multirotor_base_plugin to the base_link -->
     <gazebo>
       <plugin filename="libmav_gazebo_multirotor_base_plugin.so" name="rosbag">
-        <robotNamespace>${namespace}</robotNamespace>
+        <robotNamespace>${robot_namespace}</robotNamespace>
         <linkName>base_link</linkName>
         <rotorVelocitySlowdownSim>${rotor_velocity_slowdown_sim}</rotorVelocitySlowdownSim>
       </plugin>

--- a/mav_gazebo_plugins/include/mav_gazebo_plugins/gazebo_controller_interface.h
+++ b/mav_gazebo_plugins/include/mav_gazebo_plugins/gazebo_controller_interface.h
@@ -40,11 +40,11 @@
 namespace gazebo {
 // Default values
 static const std::string kDefaultNamespace = "";
-static const std::string kDefaultMotorVelocityReferencePubTopic = "/motor_velocity_reference";
-static const std::string kDefaultCommandAttitudeThrustSubTopic = "/command/attitude";
-static const std::string kDefaultCommandRateThrustSubTopic = "/command/rate";
-static const std::string kDefaultCommandMotorSpeedSubTopic = "/command/motors";
-static const std::string kDefaultImuSubTopic = "/imu";
+static const std::string kDefaultMotorVelocityReferencePubTopic = "motor_velocity_reference";
+static const std::string kDefaultCommandAttitudeThrustSubTopic = "command/attitude";
+static const std::string kDefaultCommandRateThrustSubTopic = "command/rate";
+static const std::string kDefaultCommandMotorSpeedSubTopic = "command/motors";
+static const std::string kDefaultImuSubTopic = "imu";
 
 
 

--- a/mav_gazebo_plugins/include/mav_gazebo_plugins/gazebo_multirotor_base_plugin.h
+++ b/mav_gazebo_plugins/include/mav_gazebo_plugins/gazebo_multirotor_base_plugin.h
@@ -28,7 +28,7 @@ namespace gazebo {
 // Default values
 static const std::string kDefaultNamespace = "";
 
-static const std::string kDefaultMotorPubTopic = "/ground_truth/pose";
+static const std::string kDefaultMotorPubTopic = "motors";
 static const std::string kDefaultLinkName = "base_link";
 static const std::string kDefaultFrameId = "base_link";
 

--- a/mav_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/mav_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -36,7 +36,6 @@ void GazeboMotorModel::Publish() {
 }
 
 void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
-  // Store the pointer to the model.
   model_ = _model;
 
   namespace_.clear();

--- a/mav_gazebo_plugins/src/gazebo_multirotor_base_plugin.cpp
+++ b/mav_gazebo_plugins/src/gazebo_multirotor_base_plugin.cpp
@@ -34,9 +34,9 @@ void GazeboMultirotorBasePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr 
   world_ = model_->GetWorld();
   namespace_.clear();
 
-  getSdfParam<std::string>(_sdf, "robotNamespace", namespace_, "", true);
-  getSdfParam<std::string>(_sdf, "linkName", link_name_, "base_link", true);
-  getSdfParam<std::string>(_sdf, "motorPubTopic", motor_pub_topic_, "motors");
+  getSdfParam<std::string>(_sdf, "robotNamespace", namespace_, namespace_, true);
+  getSdfParam<std::string>(_sdf, "linkName", link_name_, link_name_, true);
+  getSdfParam<std::string>(_sdf, "motorPubTopic", motor_pub_topic_, motor_pub_topic_);
   getSdfParam<double>(_sdf, "rotorVelocitySlowdownSim", rotor_velocity_slowdown_sim_,
                       rotor_velocity_slowdown_sim_);
 


### PR DESCRIPTION
Sorry this was done wrong during the re-factoring.
@burrimi or @markusachtelik can you please double check if everything is working with this?
