### PR TITLE
[gazebo 5] remove usage of deprecated function

### DIFF
--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
@@ -97,7 +97,6 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   std::string motor_velocity_pub_topic_;
   int motor_number_;
   int turning_direction_;
-  double max_force_;
   double motor_constant_;
   double moment_constant_;
   double time_constant_up_;

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -102,11 +102,6 @@ void GazeboMotorModel::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
 
   inertia_ = link_->GetInertial()->GetIZZ();
   viscous_friction_coefficient_ = inertia_ / time_constant_up_;
-  // Set the max_force_ to the maximum double value the limitations get handled by the FirstOrderFilter.
-  max_force_ = std::numeric_limits<double>::max();
-
-  // Set the maximumForce on the joint.
-  joint_->SetMaxForce(0, max_force_);
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.


### PR DESCRIPTION
This was needed to run the simulator in gazebo 5. `SetMaxForce` is deprecated in gazebo 5. Although it compiles with the call to `SetMaxForce` (gives a warning) the joints will not move. I am not too sure about the influence in gazebo <5 so I just park this PR here to make people aware of the issue.
