### PR TITLE
Switch to stereo cameras for VI Sensor

### DIFF
--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -178,20 +178,20 @@
   <xacro:macro name="stereo_camera_macro"
     params="namespace camera_name parent_link frame_rate
       horizontal_fov image_width image_height image_format min_distance
-      max_distance noise_mean noise_stddev enable_visual offset_x baseline_y
-      offset_z *geometry">
+      max_distance noise_mean noise_stddev enable_visual origin_offset_x
+      baseline_y origin_offset_z *geometry">
     <!-- These are parameters for the left camera link and then the right
         as well. -->
     <xacro:camera_joint_macro namespace="${namespace}"
       parent_link="${parent_link}"
       camera_suffix="left" enable_visual="${enable_visual}">
-      <origin xyz="${offset_x} ${baseline_y/2} ${offset_z}" rpy="0 0 0" />
+      <origin xyz="${origin_offset_x} ${baseline_y/2} ${origin_offset_z}" rpy="0 0 0" />
       <xacro:insert_block name="geometry" />
     </xacro:camera_joint_macro>
     <xacro:camera_joint_macro namespace="${namespace}"
       parent_link="${parent_link}"
       camera_suffix="right" enable_visual="${enable_visual}">
-      <origin xyz="${offset_x} ${-baseline_y/2} ${offset_z}" rpy="0 0 0" />
+      <origin xyz="${origin_offset_x} ${-baseline_y/2} ${origin_offset_z}" rpy="0 0 0" />
       <xacro:insert_block name="geometry" />
     </xacro:camera_joint_macro>
 
@@ -225,8 +225,6 @@
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
           <frameName>${camera_name}/camera_left_link</frameName>
-          <!-- This is unfortunately the way to get correct parameters for the
-               stereo camera. -->
           <hackBaseline>${baseline_y}</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>
@@ -394,7 +392,7 @@
 
   <!-- Macro to add a VI-sensor stereo camera. -->
   <xacro:macro name="vi_sensor_stereo_camera_macro"
-    params="namespace parent_link frame_rate offset_x baseline_y offset_z">
+    params="namespace parent_link frame_rate origin_offset_x baseline_y origin_offset_z">
     <xacro:stereo_camera_macro
       namespace="${namespace}"
       camera_name="vi_sensor"
@@ -409,9 +407,9 @@
       noise_mean="0.0"
       noise_stddev="0.007"
       enable_visual="false"
-      offset_x="${offset_x}"
+      origin_offset_x="${origin_offset_x}"
       baseline_y="${baseline_y}"
-      offset_z="${offset_z}" >
+      origin_offset_z="${origin_offset_z}" >
       <cylinder length="0.01" radius="0.007" />
     </xacro:stereo_camera_macro>
   </xacro:macro>
@@ -519,8 +517,8 @@
       <!-- Insert stereo pair. -->
       <xacro:vi_sensor_stereo_camera_macro
         namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"
-        frame_rate="30.0" offset_x="0.015" baseline_y="${0.055*2}"
-        offset_z="0.0065" >
+        frame_rate="30.0" origin_offset_x="0.015" baseline_y="${0.055*2}"
+        origin_offset_z="0.0065" >
       </xacro:vi_sensor_stereo_camera_macro>
     </xacro:if>
 

--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -115,7 +115,7 @@
   <!-- Camera joint macro - just the joints, links, and collisions for a single
        camera. -->
   <xacro:macro name="camera_joint_macro"
-    params="namespace parent_link camera_suffix enable_visual *geometry *origin" >
+    params="namespace parent_link camera_suffix enable_visual *origin *geometry" >
     <link name="${namespace}/camera_${camera_suffix}_link">
       <collision>
         <origin xyz="0 0 0" rpy="0 0 0" />
@@ -174,26 +174,28 @@
 
   <!-- Macro to add a multicamera (stereo pair). -->
   <xacro:macro name="stereo_camera_macro"
-    params="namespace parent_link frame_rate
+    params="namespace camera_name parent_link frame_rate
       horizontal_fov image_width image_height image_format min_distance
       max_distance noise_mean noise_stddev enable_visual offset_x baseline_y
-      offset_z">
+      offset_z *geometry">
     <!-- These are parameters for the left camera link and then the right
         as well. -->
     <xacro:camera_joint_macro namespace="${namespace}"
       parent_link="${parent_link}"
       camera_suffix="left" enable_visual="${enable_visual}">
       <origin xyz="${offset_x} ${baseline_y/2} ${offset_z}" rpy="0 0 0" />
+      <xacro:insert_block name="geometry" />
     </xacro:camera_joint_macro>
     <xacro:camera_joint_macro namespace="${namespace}"
       parent_link="${parent_link}"
       camera_suffix="right" enable_visual="${enable_visual}">
-      <origin xyz="{offset_x} ${-baseline_y/2} ${offset_z}" rpy="0 0 0" />
+      <origin xyz="${offset_x} ${-baseline_y/2} ${offset_z}" rpy="0 0 0" />
+      <xacro:insert_block name="geometry" />
     </xacro:camera_joint_macro>
 
     <!-- Both cameras in the pair are anchored off the left camera frame. -->
     <gazebo reference="${namespace}/camera_left_link">
-      <sensor type="multicamera" name="stereo_camera">
+      <sensor type="multicamera" name="${namespace}_stereo_camera">
         <update_rate>${frame_rate}</update_rate>
 
         <!-- Here we set up the individual cameras of the stereo head. -->
@@ -202,13 +204,20 @@
             image_height="${image_height}" image_format="${image_format}"
             min_distance="${min_distance}" max_distance="${max_distance}"
             noise_mean="${noise_mean}" noise_stddev="${noise_stddev}">
-        </xacro:camera_joint_macro>
+        </xacro:camera_sensor_macro>
+
+        <xacro:camera_sensor_macro camera_suffix="right"
+            horizontal_fov="${horizontal_fov}" image_width="${image_width}"
+            image_height="${image_height}" image_format="${image_format}"
+            min_distance="${min_distance}" max_distance="${max_distance}"
+            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}">
+        </xacro:camera_sensor_macro>
 
         <!-- Stereo controller, setting the transforms between the two cameras. -->
-        <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+        <plugin name="${namespace}_stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
           <alwaysOn>true</alwaysOn>
           <updateRate>0.0</updateRate>
-          <cameraName>camera</cameraName>
+          <cameraName>${camera_name}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
           <frameName>${namespace}/camera_left_link</frameName>
@@ -379,11 +388,12 @@
     </xacro:camera_macro>
   </xacro:macro>
 
-  <!-- Macro to add a VI-sensor camera. -->
+  <!-- Macro to add a VI-sensor stereo camera. -->
   <xacro:macro name="vi_sensor_stereo_camera_macro"
     params="namespace parent_link frame_rate offset_x baseline_y offset_z">
     <xacro:stereo_camera_macro
       namespace="${namespace}"
+      camera_name="vi_sensor"
       parent_link="${parent_link}"
       frame_rate="${frame_rate}"
       horizontal_fov="1.3962634"
@@ -397,9 +407,9 @@
       enable_visual="false"
       offset_x="${offset_x}"
       baseline_y="${baseline_y}"
-      offset_z="${offset_z}"
+      offset_z="${offset_z}" >
       <cylinder length="0.01" radius="0.007" />
-    </xacro:camera_macro>
+    </xacro:stereo_camera_macro>
   </xacro:macro>
 
   <!-- Macro to add a depth camera on the VI-sensor. -->
@@ -503,11 +513,11 @@
     <!-- Cameras -->
     <xacro:if value="${enable_cameras}">
       <!-- Insert stereo pair. -->
-      <xacro:vi_sensor_camera_macro
+      <xacro:vi_sensor_stereo_camera_macro
         namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"
         frame_rate="30.0" offset_x="0.015" baseline_y="${0.055*2}"
-        offset_z="0.0065">
-      </xacro:vi_sensor_camera_macro>
+        offset_z="0.0065" >
+      </xacro:vi_sensor_stereo_camera_macro>
       <!-- Left Camera -->
       <!-- <xacro:vi_sensor_camera_macro
         namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"

--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -112,6 +112,119 @@
     </gazebo>
   </xacro:macro>
 
+  <!-- Camera joint macro - just the joints, links, and collisions for a single
+       camera. -->
+  <xacro:macro name="camera_joint_macro"
+    params="namespace parent_link camera_suffix enable_visual *geometry *origin" >
+    <link name="${namespace}/camera_${camera_suffix}_link">
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <xacro:insert_block name="geometry" />
+        </geometry>
+      </collision>
+      <xacro:if value="${enable_visual}">
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0" />
+          <geometry>
+            <xacro:insert_block name="geometry" />
+          </geometry>
+          <material name="red" />
+        </visual>
+      </xacro:if>
+      <inertial>
+        <mass value="1e-5" />
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+      </inertial>
+    </link>
+    <joint name="${namespace}/camera_${camera_suffix}_joint" type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent_link}" />
+      <child link="${namespace}/camera_${camera_suffix}_link" />
+    </joint>
+  </xacro:macro>
+
+
+  <!-- Camera sensor macro - just image parameters. -->
+  <xacro:macro name="camera_sensor_macro"
+    params="camera_suffix horizontal_fov image_width image_height
+      image_format min_distance max_distance noise_mean noise_stddev" >
+    <camera name="${camera_suffix}">
+      <horizontal_fov>${horizontal_fov}</horizontal_fov>
+      <image>
+        <width>${image_width}</width>
+        <height>${image_height}</height>
+        <format>${image_format}</format>
+      </image>
+      <clip>
+        <near>${min_distance}</near>
+        <far>${max_distance}</far>
+      </clip>
+      <noise>
+        <type>gaussian</type>
+        <!-- Noise is sampled independently per pixel on each frame.
+             That pixel's noise value is added to each of its color
+             channels, which at that point lie in the range [0,1]. -->
+        <mean>${noise_mean}</mean>
+        <stddev>${noise_stddev}</stddev>
+      </noise>
+    </camera>
+  </xacro:macro>
+
+  <!-- Macro to add a multicamera (stereo pair). -->
+  <xacro:macro name="stereo_camera_macro"
+    params="namespace parent_link frame_rate
+      horizontal_fov image_width image_height image_format min_distance
+      max_distance noise_mean noise_stddev enable_visual offset_x baseline_y
+      offset_z">
+    <!-- These are parameters for the left camera link and then the right
+        as well. -->
+    <xacro:camera_joint_macro namespace="${namespace}"
+      parent_link="${parent_link}"
+      camera_suffix="left" enable_visual="${enable_visual}">
+      <origin xyz="${offset_x} ${baseline_y/2} ${offset_z}" rpy="0 0 0" />
+    </xacro:camera_joint_macro>
+    <xacro:camera_joint_macro namespace="${namespace}"
+      parent_link="${parent_link}"
+      camera_suffix="right" enable_visual="${enable_visual}">
+      <origin xyz="{offset_x} ${-baseline_y/2} ${offset_z}" rpy="0 0 0" />
+    </xacro:camera_joint_macro>
+
+    <!-- Both cameras in the pair are anchored off the left camera frame. -->
+    <gazebo reference="${namespace}/camera_left_link">
+      <sensor type="multicamera" name="stereo_camera">
+        <update_rate>${frame_rate}</update_rate>
+
+        <!-- Here we set up the individual cameras of the stereo head. -->
+        <xacro:camera_sensor_macro camera_suffix="left"
+            horizontal_fov="${horizontal_fov}" image_width="${image_width}"
+            image_height="${image_height}" image_format="${image_format}"
+            min_distance="${min_distance}" max_distance="${max_distance}"
+            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}">
+        </xacro:camera_joint_macro>
+
+        <!-- Stereo controller, setting the transforms between the two cameras. -->
+        <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+          <alwaysOn>true</alwaysOn>
+          <updateRate>0.0</updateRate>
+          <cameraName>camera</cameraName>
+          <imageTopicName>image_raw</imageTopicName>
+          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <frameName>${namespace}/camera_left_link</frameName>
+          <!-- This is unfortunately the way to get correct parameters for the
+               stereo camera. -->
+          <hackBaseline>${baseline_y}</hackBaseline>
+          <distortionK1>0.0</distortionK1>
+          <distortionK2>0.0</distortionK2>
+          <distortionK3>0.0</distortionK3>
+          <distortionT1>0.0</distortionT1>
+          <distortionT2>0.0</distortionT2>
+        </plugin>
+      </sensor>
+    </gazebo>
+  </xacro:macro>
+
   <!-- Macro to add the controller interface. -->
   <xacro:macro name="controller_plugin_macro" params="namespace imu_sub_topic">
     <gazebo>
@@ -266,6 +379,29 @@
     </xacro:camera_macro>
   </xacro:macro>
 
+  <!-- Macro to add a VI-sensor camera. -->
+  <xacro:macro name="vi_sensor_stereo_camera_macro"
+    params="namespace parent_link frame_rate offset_x baseline_y offset_z">
+    <xacro:stereo_camera_macro
+      namespace="${namespace}"
+      parent_link="${parent_link}"
+      frame_rate="${frame_rate}"
+      horizontal_fov="1.3962634"
+      image_width="752"
+      image_height="480"
+      image_format="L8"
+      min_distance="0.02"
+      max_distance="30"
+      noise_mean="0.0"
+      noise_stddev="0.007"
+      enable_visual="false"
+      offset_x="${offset_x}"
+      baseline_y="${baseline_y}"
+      offset_z="${offset_z}"
+      <cylinder length="0.01" radius="0.007" />
+    </xacro:camera_macro>
+  </xacro:macro>
+
   <!-- Macro to add a depth camera on the VI-sensor. -->
   <xacro:macro name="vi_sensor_depth_macro"
     params="namespace parent_link camera_suffix frame_rate *origin">
@@ -366,18 +502,24 @@
     </joint>
     <!-- Cameras -->
     <xacro:if value="${enable_cameras}">
-      <!-- Left Camera -->
+      <!-- Insert stereo pair. -->
       <xacro:vi_sensor_camera_macro
+        namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"
+        frame_rate="30.0" offset_x="0.015" baseline_y="${0.055*2}"
+        offset_z="0.0065">
+      </xacro:vi_sensor_camera_macro>
+      <!-- Left Camera -->
+      <!-- <xacro:vi_sensor_camera_macro
         namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"
         camera_suffix="left" frame_rate="30.0">
         <origin xyz="0.015 0.055 0.0065" rpy="0 0 0" />
-      </xacro:vi_sensor_camera_macro>
+      </xacro:vi_sensor_camera_macro> -->
       <!-- Right Camera -->
-      <xacro:vi_sensor_camera_macro namespace="${namespace}"
+      <!-- <xacro:vi_sensor_camera_macro namespace="${namespace}"
         parent_link="${namespace}/vi_sensor_link"
         camera_suffix="right" frame_rate="30.0">
         <origin xyz="0.015 -0.055 0.0065" rpy="0 0 0" />
-      </xacro:vi_sensor_camera_macro>
+      </xacro:vi_sensor_camera_macro> -->
     </xacro:if>
 
     <!-- Depth Sensor -->

--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -149,8 +149,10 @@
   <!-- Camera sensor macro - just image parameters. -->
   <xacro:macro name="camera_sensor_macro"
     params="camera_suffix horizontal_fov image_width image_height
-      image_format min_distance max_distance noise_mean noise_stddev" >
+      image_format min_distance max_distance noise_mean noise_stddev
+      baseline" >
     <camera name="${camera_suffix}">
+      <pose>0 ${-baseline} 0 0 0 0</pose>
       <horizontal_fov>${horizontal_fov}</horizontal_fov>
       <image>
         <width>${image_width}</width>
@@ -203,14 +205,16 @@
             horizontal_fov="${horizontal_fov}" image_width="${image_width}"
             image_height="${image_height}" image_format="${image_format}"
             min_distance="${min_distance}" max_distance="${max_distance}"
-            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}">
+            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}"
+            baseline="0">
         </xacro:camera_sensor_macro>
 
         <xacro:camera_sensor_macro camera_suffix="right"
             horizontal_fov="${horizontal_fov}" image_width="${image_width}"
             image_height="${image_height}" image_format="${image_format}"
             min_distance="${min_distance}" max_distance="${max_distance}"
-            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}">
+            noise_mean="${noise_mean}" noise_stddev="${noise_stddev}"
+            baseline="${baseline_y}">
         </xacro:camera_sensor_macro>
 
         <!-- Stereo controller, setting the transforms between the two cameras. -->
@@ -220,7 +224,7 @@
           <cameraName>${camera_name}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>${namespace}/camera_left_link</frameName>
+          <frameName>${camera_name}/camera_left_link</frameName>
           <!-- This is unfortunately the way to get correct parameters for the
                stereo camera. -->
           <hackBaseline>${baseline_y}</hackBaseline>

--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -522,18 +522,6 @@
         frame_rate="30.0" offset_x="0.015" baseline_y="${0.055*2}"
         offset_z="0.0065" >
       </xacro:vi_sensor_stereo_camera_macro>
-      <!-- Left Camera -->
-      <!-- <xacro:vi_sensor_camera_macro
-        namespace="${namespace}" parent_link="${namespace}/vi_sensor_link"
-        camera_suffix="left" frame_rate="30.0">
-        <origin xyz="0.015 0.055 0.0065" rpy="0 0 0" />
-      </xacro:vi_sensor_camera_macro> -->
-      <!-- Right Camera -->
-      <!-- <xacro:vi_sensor_camera_macro namespace="${namespace}"
-        parent_link="${namespace}/vi_sensor_link"
-        camera_suffix="right" frame_rate="30.0">
-        <origin xyz="0.015 -0.055 0.0065" rpy="0 0 0" />
-      </xacro:vi_sensor_camera_macro> -->
     </xacro:if>
 
     <!-- Depth Sensor -->


### PR DESCRIPTION
Now produces full dense disparities with stereo image proc and valid octomaps. :)
Fills out the camera_info message correctly for the stereo pair, with the correct extrinsics/rectification parameters.

Unfortunate side-effect of using the proper stereo model is that the topic names have changed from:
```
/firefly/vi_sensor/camera_left/camera_info
/firefly/vi_sensor/camera_left/image_raw
/firefly/vi_sensor/camera_right/camera_info
/firefly/vi_sensor/camera_right/image_raw
```

to
```
/firefly/vi_sensor/left/camera_info
/firefly/vi_sensor/left/image_raw
/firefly/vi_sensor/right/camera_info
/firefly/vi_sensor/right/image_raw
```

Which is more fitting with the ROS convention anyway.

Here are some screenshots for fun.
![dense_disparity](https://cloud.githubusercontent.com/assets/5616392/7137041/9ed92f4c-e2b6-11e4-9b1c-68f4aca353bd.png)
(Super dense disparity!)

![working_rotors](https://cloud.githubusercontent.com/assets/5616392/7137045/a1ed97d6-e2b6-11e4-97db-7251f4773b79.png)
(Left and right camera images and the generated octomap in the background).

![gazebo_thing](https://cloud.githubusercontent.com/assets/5616392/7137054/a930efc0-e2b6-11e4-8018-7bd84368d4fa.png)
(White cylinders overlaid is the position of the camera links, which is luckily on top of the actual physical model cameras).

@birchera, for you! :)
@ffurrer and/or @burrimi, if you guys could verify my xacro-ing, that would be awesome. Some parts of this feel not great.