### PR TITLE
Fix relevant trajectory includes.

### DIFF
--- a/rotors_gazebo/src/hovering_example.cpp
+++ b/rotors_gazebo/src/hovering_example.cpp
@@ -26,7 +26,7 @@
 #include <mav_msgs/default_topics.h>
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
-#include <trajectory_msgs/MultiDOFJointTrajectoryPoint.h>
+#include <trajectory_msgs/MultiDOFJointTrajectory.h>
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "hovering_example");


### PR DESCRIPTION
Resolves #261.

conversions.h brings in the relevant includes (so it doesn't fail to compile), but now we include the thing we actually use. :)