### PR TITLE
Feature/surface octomap

### DIFF
--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
@@ -54,6 +54,22 @@ class OctomapFromGazeboWorld : public WorldPlugin {
                  const math::Vector3& bounding_box_origin,
                  const math::Vector3& bounding_box_lengths,
                  const double leaf_size);
+  /*! \brief Creates octomap by floodfilling freespace.
+  *
+  * Creates an octomap of the environment in 3 steps:
+  *   -# Casts rays along the central X,Y and Z axis of each cell. Marks any 
+  *     cell where a ray intersects a mesh as occupied
+  *   -# Floodfills the area from the top and bottom marking all connected
+  *     space that has not been set to occupied as free.
+  *   -# Labels all remaining unknown space as occupied.
+  *
+  * Can give incorrect results in the following situations:
+  *   -# The top central cell or bottom central cell are either occupied or
+  *     completely enclosed by occupied cells.
+  *   -# A completely enclosed hollow space will be marked as occupied.
+  *   -# Cells containing a mesh that does not intersect its central axes will
+  *     be marked as unoccupied
+  */
   void CreateOctomap(const rotors_comm::Octomap::Request& msg);
 
  private:

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
@@ -49,8 +49,13 @@ class OctomapFromGazeboWorld : public WorldPlugin {
   /// \param[in] _parent Pointer to the world that loaded this plugin.
   /// \param[in] _sdf SDF element that describes the plugin.
   void Load(physics::WorldPtr _parent, sdf::ElementPtr _sdf);
-  bool CheckIfInterests(const math::Vector3& central_point, gazebo::physics::RayShapePtr ray, const double leaf_size);
-  void FloodFill(const math::Vector3& seed_point, const math::Vector3& bounding_box_origin, const math::Vector3& bounding_box_lengths, const double leaf_size);
+  bool CheckIfInterest(const math::Vector3& central_point, 
+                      gazebo::physics::RayShapePtr ray,
+                      const double leaf_size);
+  void FloodFill(const math::Vector3& seed_point, 
+                const math::Vector3& bounding_box_origin, 
+                const math::Vector3& bounding_box_lengths, 
+                const double leaf_size);
   void CreateOctomap(const rotors_comm::Octomap::Request& msg);
 
  private:
@@ -58,7 +63,8 @@ class OctomapFromGazeboWorld : public WorldPlugin {
   ros::NodeHandle node_handle_;
   ros::ServiceServer srv_;
   octomap::OcTree* octomap_;
-  bool ServiceCallback(rotors_comm::Octomap::Request& req, rotors_comm::Octomap::Response& res);
+  bool ServiceCallback(rotors_comm::Octomap::Request& req, 
+                      rotors_comm::Octomap::Response& res);
 };
 
 }

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
@@ -49,8 +49,8 @@ class OctomapFromGazeboWorld : public WorldPlugin {
   /// \param[in] _parent Pointer to the world that loaded this plugin.
   /// \param[in] _sdf SDF element that describes the plugin.
   void Load(physics::WorldPtr _parent, sdf::ElementPtr _sdf);
-  bool CheckIfInsideObject(const std::string& name, const math::Vector3& central_point, gazebo::physics::RayShapePtr ray);
-  bool CheckIfInsideObjectInX(const std::string& name, const math::Vector3& central_point, gazebo::physics::RayShapePtr ray);
+  bool CheckIfInterests(const math::Vector3& central_point, gazebo::physics::RayShapePtr ray, const double leaf_size);
+  void FloodFill(const math::Vector3& seed_point, const math::Vector3& bounding_box_origin, const math::Vector3& bounding_box_lengths, const double leaf_size);
   void CreateOctomap(const rotors_comm::Octomap::Request& msg);
 
  private:

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_octomap_plugin.h
@@ -39,9 +39,7 @@ namespace gazebo {
 class OctomapFromGazeboWorld : public WorldPlugin {
  public:
   OctomapFromGazeboWorld()
-      : WorldPlugin(),
-        node_handle_(kDefaultNamespace),
-        octomap_(NULL) {}
+      : WorldPlugin(), node_handle_(kDefaultNamespace), octomap_(NULL) {}
   virtual ~OctomapFromGazeboWorld();
 
  protected:
@@ -49,13 +47,13 @@ class OctomapFromGazeboWorld : public WorldPlugin {
   /// \param[in] _parent Pointer to the world that loaded this plugin.
   /// \param[in] _sdf SDF element that describes the plugin.
   void Load(physics::WorldPtr _parent, sdf::ElementPtr _sdf);
-  bool CheckIfInterest(const math::Vector3& central_point, 
-                      gazebo::physics::RayShapePtr ray,
-                      const double leaf_size);
-  void FloodFill(const math::Vector3& seed_point, 
-                const math::Vector3& bounding_box_origin, 
-                const math::Vector3& bounding_box_lengths, 
-                const double leaf_size);
+  bool CheckIfInterest(const math::Vector3& central_point,
+                       gazebo::physics::RayShapePtr ray,
+                       const double leaf_size);
+  void FloodFill(const math::Vector3& seed_point,
+                 const math::Vector3& bounding_box_origin,
+                 const math::Vector3& bounding_box_lengths,
+                 const double leaf_size);
   void CreateOctomap(const rotors_comm::Octomap::Request& msg);
 
  private:
@@ -63,10 +61,9 @@ class OctomapFromGazeboWorld : public WorldPlugin {
   ros::NodeHandle node_handle_;
   ros::ServiceServer srv_;
   octomap::OcTree* octomap_;
-  bool ServiceCallback(rotors_comm::Octomap::Request& req, 
-                      rotors_comm::Octomap::Response& res);
+  bool ServiceCallback(rotors_comm::Octomap::Request& req,
+                       rotors_comm::Octomap::Response& res);
 };
-
 }
 
-#endif // ROTORS_GAZEBO_PLUGINS_GAZEBO_OCTOMAP_PLUGIN_H
+#endif  // ROTORS_GAZEBO_PLUGINS_GAZEBO_OCTOMAP_PLUGIN_H

--- a/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
@@ -196,6 +196,14 @@ void OctomapFromGazeboWorld::CreateOctomap(const rotors_comm::Octomap::Request& 
   }
   octomap_->prune();
   octomap_->updateInnerOccupancy();
+
+  math::Vector3 seed_point(bounding_box_origin.x + bounding_box_lengths.x/2 - leaf_size/2,
+    )
+  FloodFill(math::Vector3(bounding_box_origin.x + bounding_box_lengths.x/2 - leaf_size/2,
+    bounding_box_origin.y + bounding_box_lengths.y/2 - leaf_size/2,
+    bounding_box_origin.z + bounding_box_lengths.z/2 - leaf_size/2),
+    bounding_box_origin, bounding_box_lengths, leaf_size);
+
 }
 
 // Register this plugin with the simulator

--- a/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-
 #include "rotors_gazebo_plugins/gazebo_octomap_plugin.h"
 
 #include <gazebo/common/Time.hh>
@@ -32,33 +31,31 @@ OctomapFromGazeboWorld::~OctomapFromGazeboWorld() {
   octomap_ = NULL;
 }
 
-void OctomapFromGazeboWorld::Load(physics::WorldPtr _parent, 
+void OctomapFromGazeboWorld::Load(physics::WorldPtr _parent,
                                   sdf::ElementPtr _sdf) {
   world_ = _parent;
   std::string service_name = "world/get_octomap";
   gzlog << "Advertising service: " << service_name << std::endl;
-  srv_ = node_handle_.advertiseService(service_name,
-   &OctomapFromGazeboWorld::ServiceCallback, this);
+  srv_ = node_handle_.advertiseService(
+      service_name, &OctomapFromGazeboWorld::ServiceCallback, this);
 }
 
-bool OctomapFromGazeboWorld::ServiceCallback(rotors_comm::Octomap::Request& req,
-    rotors_comm::Octomap::Response& res) {
-  std::cout << "Creating octomap with origin at (" 
-            << req.bounding_box_origin.x 
-            << ", " << req.bounding_box_origin.y
-            << ", " << req.bounding_box_origin.z 
-            << "), and bounding box lengths (" << req.bounding_box_lengths.x
-            << ", " << req.bounding_box_lengths.y << ", " 
-            << req.bounding_box_lengths.z << "), and leaf size: "
-            << req.leaf_size << ".\n";
+bool OctomapFromGazeboWorld::ServiceCallback(
+    rotors_comm::Octomap::Request& req, rotors_comm::Octomap::Response& res) {
+  std::cout << "Creating octomap with origin at (" << req.bounding_box_origin.x
+            << ", " << req.bounding_box_origin.y << ", "
+            << req.bounding_box_origin.z << "), and bounding box lengths ("
+            << req.bounding_box_lengths.x << ", " << req.bounding_box_lengths.y
+            << ", " << req.bounding_box_lengths.z
+            << "), and leaf size: " << req.leaf_size << ".\n";
   CreateOctomap(req);
   if (req.filename != "") {
     if (octomap_) {
       std::string path = req.filename;
       octomap_->writeBinary(path);
-      std::cout << std::endl << "Octree saved as " << path << std::endl;
-    }
-    else {
+      std::cout << std::endl
+                << "Octree saved as " << path << std::endl;
+    } else {
       std::cout << "The octree is NULL. Will not save that." << std::endl;
     }
   }
@@ -70,24 +67,20 @@ bool OctomapFromGazeboWorld::ServiceCallback(rotors_comm::Octomap::Request& req,
     res.map.id = "OcTree";
     res.map.binary = true;
     res.map.resolution = octomap_->getResolution();
-  }
-  else {
+  } else {
     ROS_ERROR("Error serializing OctoMap");
   }
   std::cout << "Publishing Octomap." << std::endl;
   return true;
 }
 
-void OctomapFromGazeboWorld::FloodFill(const math::Vector3& seed_point, 
-                                      const math::Vector3& bounding_box_origin, 
-                                      const math::Vector3& bounding_box_lengths,
-                                      const double leaf_size) {
-  //do nothing if point occupied
-  octomap::OcTreeNode* seed = octomap_->search(seed_point.x,
-                                              seed_point.y,
-                                              seed_point.z);
-  if (seed != NULL && seed->getOccupancy())
-    return;
+void OctomapFromGazeboWorld::FloodFill(
+    const math::Vector3& seed_point, const math::Vector3& bounding_box_origin,
+    const math::Vector3& bounding_box_lengths, const double leaf_size) {
+  octomap::OcTreeNode* seed =
+      octomap_->search(seed_point.x, seed_point.y, seed_point.z);
+  // do nothing if point occupied
+  if (seed != NULL && seed->getOccupancy()) return;
 
   std::stack<octomath::Vector3> to_check;
   to_check.push(octomath::Vector3(seed_point.x, seed_point.y, seed_point.z));
@@ -95,14 +88,13 @@ void OctomapFromGazeboWorld::FloodFill(const math::Vector3& seed_point,
   while (to_check.size() > 0) {
     octomath::Vector3 p = to_check.top();
 
-    if ((p.x() >  bounding_box_origin.x - bounding_box_lengths.x / 2) &&
-        (p.x() <  bounding_box_origin.x + bounding_box_lengths.x / 2) &&
-        (p.y() >  bounding_box_origin.y - bounding_box_lengths.y / 2) &&
-        (p.y() <  bounding_box_origin.y + bounding_box_lengths.y / 2) &&
-        (p.z() >  bounding_box_origin.z - bounding_box_lengths.z / 2) &&
-        (p.z() <  bounding_box_origin.z + bounding_box_lengths.z / 2) &&
+    if ((p.x() > bounding_box_origin.x - bounding_box_lengths.x / 2) &&
+        (p.x() < bounding_box_origin.x + bounding_box_lengths.x / 2) &&
+        (p.y() > bounding_box_origin.y - bounding_box_lengths.y / 2) &&
+        (p.y() < bounding_box_origin.y + bounding_box_lengths.y / 2) &&
+        (p.z() > bounding_box_origin.z - bounding_box_lengths.z / 2) &&
+        (p.z() < bounding_box_origin.z + bounding_box_lengths.z / 2) &&
         (!octomap_->search(p))) {
-
       octomap_->setNodeValue(p, 0);
       to_check.pop();
       to_check.push(octomath::Vector3(p.x() + leaf_size, p.y(), p.z()));
@@ -112,18 +104,15 @@ void OctomapFromGazeboWorld::FloodFill(const math::Vector3& seed_point,
       to_check.push(octomath::Vector3(p.x(), p.y(), p.z() + leaf_size));
       to_check.push(octomath::Vector3(p.x(), p.y(), p.z() - leaf_size));
 
-    }
-    else {
+    } else {
       to_check.pop();
     }
-
   }
-
 }
 
 bool OctomapFromGazeboWorld::CheckIfInterest(const math::Vector3& central_point,
-                                            gazebo::physics::RayShapePtr ray,
-                                            const double leaf_size) {
+                                             gazebo::physics::RayShapePtr ray,
+                                             const double leaf_size) {
   math::Vector3 start_point = central_point;
   math::Vector3 end_point = central_point;
 
@@ -135,8 +124,7 @@ bool OctomapFromGazeboWorld::CheckIfInterest(const math::Vector3& central_point,
   ray->SetPoints(start_point, end_point);
   ray->GetIntersection(dist, entity_name);
 
-  if (dist <= leaf_size)
-    return true;
+  if (dist <= leaf_size) return true;
 
   start_point = central_point;
   end_point = central_point;
@@ -145,8 +133,7 @@ bool OctomapFromGazeboWorld::CheckIfInterest(const math::Vector3& central_point,
   ray->SetPoints(start_point, end_point);
   ray->GetIntersection(dist, entity_name);
 
-  if (dist <= leaf_size)
-    return true;
+  if (dist <= leaf_size) return true;
 
   start_point = central_point;
   end_point = central_point;
@@ -155,22 +142,21 @@ bool OctomapFromGazeboWorld::CheckIfInterest(const math::Vector3& central_point,
   ray->SetPoints(start_point, end_point);
   ray->GetIntersection(dist, entity_name);
 
-  if (dist <= leaf_size)
-    return true;
+  if (dist <= leaf_size) return true;
 
   return false;
 }
 
 void OctomapFromGazeboWorld::CreateOctomap(
-                                     const rotors_comm::Octomap::Request& msg) {
+    const rotors_comm::Octomap::Request& msg) {
   const double epsilon = 0.00001;
   const int far_away = 100000;
-  math::Vector3 bounding_box_origin(msg.bounding_box_origin.x, 
-                                    msg.bounding_box_origin.y, 
+  math::Vector3 bounding_box_origin(msg.bounding_box_origin.x,
+                                    msg.bounding_box_origin.y,
                                     msg.bounding_box_origin.z);
-  //epsilion prevents undefiened behaviour if a point is inserted exactly 
-  //between two octomap cells
-  math::Vector3 bounding_box_lengths(msg.bounding_box_lengths.x + epsilon, 
+  // epsilion prevents undefiened behaviour if a point is inserted exactly
+  // between two octomap cells
+  math::Vector3 bounding_box_lengths(msg.bounding_box_lengths.x + epsilon,
                                      msg.bounding_box_lengths.y + epsilon,
                                      msg.bounding_box_lengths.z + epsilon);
   double leaf_size = msg.leaf_size;
@@ -184,32 +170,29 @@ void OctomapFromGazeboWorld::CreateOctomap(
 
   gazebo::physics::PhysicsEnginePtr engine = world_->GetPhysicsEngine();
   engine->InitForThread();
-  gazebo::physics::RayShapePtr ray = boost::dynamic_pointer_cast 
-                                     < gazebo::physics::RayShape
-                                     > (engine->CreateShape("ray", 
-                                        gazebo::physics::CollisionPtr()));
+  gazebo::physics::RayShapePtr ray =
+      boost::dynamic_pointer_cast<gazebo::physics::RayShape>(
+          engine->CreateShape("ray", gazebo::physics::CollisionPtr()));
 
   std::cout << "Rasterizing world and checking collisions" << std::endl;
 
-  for (double x = leaf_size / 2 + bounding_box_origin.x
-                  - bounding_box_lengths.x / 2;
-       x < bounding_box_origin.x + bounding_box_lengths.x / 2;
-       x += leaf_size) {
-    int progress = round(100 * (x + bounding_box_lengths.x / 2 
-                         - bounding_box_origin.x) / bounding_box_lengths.x);
-    std::cout << "\rPlacing model edges into octomap... "
-              << progress << "%                 ";
+  for (double x =
+           leaf_size / 2 + bounding_box_origin.x - bounding_box_lengths.x / 2;
+       x < bounding_box_origin.x + bounding_box_lengths.x / 2; x += leaf_size) {
+    int progress =
+        round(100 * (x + bounding_box_lengths.x / 2 - bounding_box_origin.x) /
+              bounding_box_lengths.x);
+    std::cout << "\rPlacing model edges into octomap... " << progress
+              << "%                 ";
 
-    for (double y = leaf_size / 2 + bounding_box_origin.y
-                    - bounding_box_lengths.y / 2;
+    for (double y =
+             leaf_size / 2 + bounding_box_origin.y - bounding_box_lengths.y / 2;
          y < bounding_box_origin.y + bounding_box_lengths.y / 2;
          y += leaf_size) {
-
-      for (double z = leaf_size / 2 + bounding_box_origin.z 
-                      - bounding_box_lengths.z / 2;
+      for (double z = leaf_size / 2 + bounding_box_origin.z -
+                      bounding_box_lengths.z / 2;
            z < bounding_box_origin.z + bounding_box_lengths.z / 2;
            z += leaf_size) {
-
         math::Vector3 point(x, y, z);
         if (CheckIfInterest(point, ray, leaf_size)) {
           octomap_->setNodeValue(x, y, z, 1);
@@ -220,44 +203,41 @@ void OctomapFromGazeboWorld::CreateOctomap(
   octomap_->prune();
   octomap_->updateInnerOccupancy();
 
-  //flood fill from top and bottom
+  // flood fill from top and bottom
   std::cout << "\rFlood filling freespace...                                  ";
-  FloodFill(math::Vector3(bounding_box_origin.x + leaf_size / 2, 
+  FloodFill(math::Vector3(bounding_box_origin.x + leaf_size / 2,
                           bounding_box_origin.y + leaf_size / 2,
-                          bounding_box_origin.z + bounding_box_lengths.z / 2 
-                                                - leaf_size / 2),
+                          bounding_box_origin.z + bounding_box_lengths.z / 2 -
+                              leaf_size / 2),
             bounding_box_origin, bounding_box_lengths, leaf_size);
-  FloodFill(math::Vector3(bounding_box_origin.x + leaf_size / 2, 
+  FloodFill(math::Vector3(bounding_box_origin.x + leaf_size / 2,
                           bounding_box_origin.y + leaf_size / 2,
-                          bounding_box_origin.z - bounding_box_lengths.z / 2
-                                                + leaf_size / 2),
+                          bounding_box_origin.z - bounding_box_lengths.z / 2 +
+                              leaf_size / 2),
             bounding_box_origin, bounding_box_lengths, leaf_size);
 
   octomap_->prune();
   octomap_->updateInnerOccupancy();
 
-  //set unknown to filled
-  for (double x = leaf_size / 2 + bounding_box_origin.x 
-                  - bounding_box_lengths.x / 2;
-       x < bounding_box_origin.x + bounding_box_lengths.x / 2;
-       x += leaf_size) {
-    int progress = round(100 * (x + bounding_box_lengths.x / 2 
-                         - bounding_box_origin.x) / bounding_box_lengths.x);
+  // set unknown to filled
+  for (double x =
+           leaf_size / 2 + bounding_box_origin.x - bounding_box_lengths.x / 2;
+       x < bounding_box_origin.x + bounding_box_lengths.x / 2; x += leaf_size) {
+    int progress =
+        round(100 * (x + bounding_box_lengths.x / 2 - bounding_box_origin.x) /
+              bounding_box_lengths.x);
     std::cout << "\rFilling closed spaces... " << progress << "%              ";
 
-    for (double y = leaf_size / 2 + bounding_box_origin.y 
-                    - bounding_box_lengths.y / 2;
+    for (double y =
+             leaf_size / 2 + bounding_box_origin.y - bounding_box_lengths.y / 2;
          y < bounding_box_origin.y + bounding_box_lengths.y / 2;
          y += leaf_size) {
-
-      for (double z = leaf_size / 2 + bounding_box_origin.z 
-                      - bounding_box_lengths.z / 2;
+      for (double z = leaf_size / 2 + bounding_box_origin.z -
+                      bounding_box_lengths.z / 2;
            z < bounding_box_origin.z + bounding_box_lengths.z / 2;
            z += leaf_size) {
-
         octomap::OcTreeNode* seed = octomap_->search(x, y, z);
-        if (!seed)
-          octomap_->setNodeValue(x, y, z, 1);
+        if (!seed) octomap_->setNodeValue(x, y, z, 1);
       }
     }
   }
@@ -266,7 +246,6 @@ void OctomapFromGazeboWorld::CreateOctomap(
   octomap_->updateInnerOccupancy();
 
   std::cout << "\rOctomap generation completed                  " << std::endl;
-
 }
 
 // Register this plugin with the simulator

--- a/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
@@ -72,95 +72,81 @@ bool OctomapFromGazeboWorld::ServiceCallback(rotors_comm::Octomap::Request& req,
   return true;
 }
 
-bool OctomapFromGazeboWorld::CheckIfInsideObject(const std::string& name, const math::Vector3& central_point,
-                                                 gazebo::physics::RayShapePtr ray) {
-  const double epsilon = 0.00001;
-  const int far_away = 100000;
-  double dist;
-  std::string entity_name;
-  // Set the end of the ray to somewhere far away
+void OctomapFromGazeboWorld::FloodFill(const math::Vector3& seed_point, const math::Vector3& bounding_box_origin, const math::Vector3& bounding_box_lengths, const double leaf_size) {
 
-  math::Vector3 start_point = central_point;
-  math::Vector3 end_point = central_point;
+  //do nothing is point occupied
+  octomap::OcTreeNode* seed = octomap_->search(seed_point.x,seed_point.y,seed_point.z);
+  if(seed != NULL && seed->getOccupancy())
+    return;
 
-  end_point.x = far_away;
+    //octomap_->setNodeValue(seed_point.x, seed_point.y, seed_point.z, 0); 
 
-  ray->SetPoints(start_point, end_point);
+    std::stack<octomath::Vector3> to_check;
+    to_check.push(octomath::Vector3(seed_point.x,seed_point.y,seed_point.z));
 
-  // Check if there is an intersection in the front
-  ray->GetIntersection(dist, entity_name);
+    while(to_check.size() > 0){
+      octomath::Vector3 p = to_check.top();
 
-  int counter = 0;
+      if((p.x() >  bounding_box_origin.x - bounding_box_lengths.x/2) &&
+        (p.x() <  bounding_box_origin.x + bounding_box_lengths.x/2) &&
+        (p.x() >  bounding_box_origin.y - bounding_box_lengths.y/2) &&
+        (p.x() <  bounding_box_origin.y + bounding_box_lengths.y/2) &&
+        (p.x() >  bounding_box_origin.z - bounding_box_lengths.z/2) &&
+        (p.x() <  bounding_box_origin.z + bounding_box_lengths.z/2) &&
+        (octomap_->search(p))->getOccupancy()) {
 
-  while (entity_name != name && start_point.x < far_away && counter < 6) {
-    start_point.x += dist + epsilon;
-    ray->SetPoints(start_point, end_point);
-    // Check if there is an intersection in the front
-    ray->GetIntersection(dist, entity_name);
-    ++counter;
-  }
+          octomap_->setNodeValue(p,1);
+          to_check.pop();
+          to_check.push(octomath::Vector3(p.x()+leaf_size,p.y(),p.z()));
+          to_check.push(octomath::Vector3(p.x()-leaf_size,p.y(),p.z()));
+          to_check.push(octomath::Vector3(p.x(),p.y()+leaf_size,p.z()));
+          to_check.push(octomath::Vector3(p.x(),p.y()-leaf_size,p.z()));
+          to_check.push(octomath::Vector3(p.x(),p.y(),p.z()-leaf_size));
+          to_check.push(octomath::Vector3(p.x(),p.y(),p.z()-leaf_size));
 
-  counter = 0;
-  start_point = central_point;
-  end_point = central_point;
-  end_point.y = far_away;
+      }
+      else {
+        to_check.pop();
+      }
+      
+    }
 
-  while (entity_name != name && start_point.y < far_away && counter < 6) {
-    start_point.y += dist + epsilon;
-    ray->SetPoints(start_point, end_point);
-    // Check if there is an intersection in the front
-    ray->GetIntersection(dist, entity_name);
-    ++counter;
-  }
-
-  counter = 0;
-  start_point = central_point;
-  end_point = central_point;
-  end_point.z = far_away;
-
-  while (entity_name != name && start_point.z < far_away && counter < 6) {
-    start_point.z += dist + epsilon;
-    ray->SetPoints(start_point, end_point);
-    // Check if there is an intersection in the front
-    ray->GetIntersection(dist, entity_name);
-    ++counter;
-  }
-
-  if (entity_name == name)
-    return true;
-
-  return false;
 }
 
-bool OctomapFromGazeboWorld::CheckIfInsideObjectInX(const std::string& name, const math::Vector3& central_point,
-                                                    gazebo::physics::RayShapePtr ray) {
-  const double epsilon = 0.00001;
-  const int far_away = 100000;
-  double dist;
-  std::string entity_name;
-  // Set the end of the ray to somewhere far away
+bool OctomapFromGazeboWorld::CheckIfInterests(const math::Vector3& central_point, gazebo::physics::RayShapePtr ray, const double leaf_size) {
 
   math::Vector3 start_point = central_point;
   math::Vector3 end_point = central_point;
 
-  end_point.x = far_away;
+  double dist;
+  std::string entity_name;
 
+  start_point.x += leaf_size/2;
+  end_point.x -= leaf_size/2;
   ray->SetPoints(start_point, end_point);
-
-  // Check if there is an intersection in the front
   ray->GetIntersection(dist, entity_name);
 
-  int counter = 0;
+  if(dist <= leaf_size)
+    return true;
 
-  while (entity_name != name && start_point.x < far_away && counter < 6) {
-    start_point.x += dist + epsilon;
-    ray->SetPoints(start_point, end_point);
-    // Check if there is an intersection in the front
-    ray->GetIntersection(dist, entity_name);
-    ++counter;
-  }
+  start_point = central_point;
+  end_point = central_point;
+  start_point.y += leaf_size/2;
+  end_point.y-= leaf_size/2;
+  ray->SetPoints(start_point, end_point);
+  ray->GetIntersection(dist, entity_name);
 
-  if (entity_name == name)
+  if(dist <= leaf_size)
+    return true;
+
+  start_point = central_point;
+  end_point = central_point;
+  start_point.z += leaf_size/2;
+  end_point.z -= leaf_size/2;
+  ray->SetPoints(start_point, end_point);
+  ray->GetIntersection(dist, entity_name);
+
+  if(dist <= leaf_size)
     return true;
 
   return false;
@@ -170,10 +156,8 @@ void OctomapFromGazeboWorld::CreateOctomap(const rotors_comm::Octomap::Request& 
   const double epsilon = 0.00001;
   const int far_away = 100000;
   math::Vector3 bounding_box_origin(msg.bounding_box_origin.x, msg.bounding_box_origin.y, msg.bounding_box_origin.z);
-  // add epsilon to the box, because octomap has undefined behaviour if the
-  // point you want to insert is exactly between two leafs (doesn't look nice :).
-  math::Vector3 bounding_box_lengths(msg.bounding_box_lengths.x + epsilon, msg.bounding_box_lengths.y + epsilon,
-                                     msg.bounding_box_lengths.z + epsilon);
+  math::Vector3 bounding_box_lengths(msg.bounding_box_lengths.x+epsilon, msg.bounding_box_lengths.y+epsilon,
+                                     msg.bounding_box_lengths.z+epsilon);
   double leaf_size = msg.leaf_size;
   octomap_ = new octomap::OcTree(leaf_size);
   octomap_->clear();
@@ -183,138 +167,30 @@ void OctomapFromGazeboWorld::CreateOctomap(const rotors_comm::Octomap::Request& 
   octomap_->setClampingThresMax(0.97);
   octomap_->setOccupancyThres(0.7);
 
-  int count_x = bounding_box_lengths.x / leaf_size;
-  int count_y = bounding_box_lengths.y / leaf_size;
-  int count_z = bounding_box_lengths.z / leaf_size;
-
-  if (count_x == 0 || count_y == 0 || count_z == 0) {
-    std::cout << "Octomap has a zero dimension, check input msg." << std::endl;
-    return;
-  }
-
   gazebo::physics::PhysicsEnginePtr engine = world_->GetPhysicsEngine();
   engine->InitForThread();
   gazebo::physics::RayShapePtr ray = boost::dynamic_pointer_cast < gazebo::physics::RayShape
       > (engine->CreateShape("ray", gazebo::physics::CollisionPtr()));
 
   std::cout << "Rasterizing world and checking collisions" << std::endl;
-  bool in_object = false;
-  for (int i = 0; i < count_z; ++i) {
-    std::cout << "Percent complete: " << i * 100.0 / count_z << std::endl;
-    double z = i * leaf_size + (bounding_box_origin.z - bounding_box_lengths.z / 2);
-    for (int j = 0; j < count_y; ++j) {
-      double y = j * leaf_size + (bounding_box_origin.y - bounding_box_lengths.y / 2);
 
-      std::map<std::string, bool> objects_in_collision;
+  for (double x = leaf_size/2 + bounding_box_origin.x - bounding_box_lengths.x/2; 
+    x < bounding_box_origin.x + bounding_box_lengths.x/2;
+    x += leaf_size) {
+    std::cout << "Running " << x << std::endl;
+    
+    for (double y = leaf_size/2 + bounding_box_origin.y - bounding_box_lengths.y/2; 
+      y < bounding_box_origin.y + bounding_box_lengths.y/2;
+      y += leaf_size) {
 
-      std::string entity_name, entity_name_backwards;
-      double dist, x;
-      math::Vector3 start, end, start_prev;
+      for (double z = leaf_size/2 + bounding_box_origin.z - bounding_box_lengths.z/2; 
+        z < bounding_box_origin.z + bounding_box_lengths.z/2;
+        z += leaf_size) {
 
-      start.y = end.y = y;
-      start.z = end.z = z;
-
-      // Set the start point of the ray to the beginning of the bounding box
-      start.x = bounding_box_origin.x - bounding_box_lengths.x / 2 - leaf_size / 2;
-      x = start.x + leaf_size / 2;
-
-      // Set the end of the ray to some large value behind itself to check
-      // if there is a boundary of an object at the current y-z location in -x
-      end.x = -far_away;
-      ray->SetPoints(start, end);
-
-      // Check if there is an intersection in the back
-      ray->GetIntersection(dist, entity_name_backwards);
-
-      bool inside_object = CheckIfInsideObject(entity_name_backwards, start, ray);
-
-      // Set in_object to true, if currently in an object
-      if (!entity_name_backwards.empty() && inside_object) {
-        objects_in_collision.insert(std::pair<std::string, bool>(entity_name_backwards, true));
-      }
-
-      // Set the end of the ray to the end of the bounding box
-      end.x = bounding_box_origin.x + bounding_box_lengths.x / 2 + leaf_size / 2;
-
-      ray->SetPoints(start, end);
-
-      // Check if there is an object at the current location
-      ray->GetIntersection(dist, entity_name);
-
-      while (!entity_name.empty() && start.x < end.x) {
-
-        while (x < start.x + dist && x < end.x - leaf_size / 2) {
-          if (!objects_in_collision.empty()) {
-            octomap_->setNodeValue(x, y, z, 1);
-          } else {
-            octomap_->setNodeValue(x, y, z, 0);
-          }
-          x += leaf_size;
+        math::Vector3 point(x,y,z);
+        if(CheckIfInterests(point, ray, leaf_size)){
+          octomap_->setNodeValue(x,y,z,1);
         }
-
-        std::map<std::string, bool>::iterator it = objects_in_collision.find(entity_name);
-        if (it != objects_in_collision.end()) {
-          objects_in_collision.erase(it);
-        } else {
-          objects_in_collision.insert(std::pair<std::string, bool>(entity_name, true));
-        }
-
-        start_prev = start;
-
-        // Set the new starting point just after the last intersection
-        start.x += dist + epsilon;
-
-        start_prev.x = start.x - epsilon;
-
-        // search back
-        ray->SetPoints(start, start_prev);
-        ray->GetIntersection(dist, entity_name_backwards);
-        if (!entity_name_backwards.empty() && entity_name != entity_name_backwards) {
-          std::map<std::string, bool>::iterator it = objects_in_collision.find(entity_name_backwards);
-          if (it != objects_in_collision.end()) {
-            std::cout << "NOT THE SAME ELEMENT ERASE" << std::endl;
-
-            objects_in_collision.erase(it);
-          } else {
-            std::cout << "NOT THE SAME ELEMENT ADD" << std::endl;
-
-            objects_in_collision.insert(std::pair<std::string, bool>(entity_name_backwards, true));
-          }
-        }
-
-//        // garbage collector
-//        for(std::map<std::string,bool>::iterator it = objects_in_collision.begin(); it != objects_in_collision.end(); it++) {
-//            if(!CheckIfInsideObjectInX(it->first,start,ray)){
-//              objects_in_collision.erase(it);
-//            }
-//        }
-        ray->SetPoints(start, end);
-        ray->GetIntersection(dist, entity_name);
-      }
-
-      math::Vector3 end_new = end;
-      end_new.x -= (leaf_size / 2 + epsilon);
-
-      start.x = x;
-
-      // garbage collector
-      for (std::map<std::string, bool>::iterator it = objects_in_collision.begin();
-           it != objects_in_collision.end(); ) {
-        if (!CheckIfInsideObjectInX(it->first, start, ray)) {
-          it = objects_in_collision.erase(it);
-        } else {
-          ++it;
-        }
-      }
-
-      // Loop until the end of the bounding box and fill the leafs
-      while (x < end.x - leaf_size / 2) {
-        if (!objects_in_collision.empty()) {
-          octomap_->setNodeValue(x, y, z, 1);
-        } else {
-          octomap_->setNodeValue(x, y, z, 0);
-        }
-        x += leaf_size;
       }
     }
   }

--- a/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_octomap_plugin.cpp
@@ -195,9 +195,10 @@ void OctomapFromGazeboWorld::CreateOctomap(
                   - bounding_box_lengths.x / 2;
        x < bounding_box_origin.x + bounding_box_lengths.x / 2;
        x += leaf_size) {
+    int progress = round(100 * (x + bounding_box_lengths.x / 2 
+                         - bounding_box_origin.x) / bounding_box_lengths.x);
     std::cout << "\rPlacing model edges into octomap... "
-              << 100 * (x + bounding_box_lengths.x / 2 - bounding_box_origin.x)
-                 / bounding_box_lengths.x << "%%                 ";
+              << progress << "%                 ";
 
     for (double y = leaf_size / 2 + bounding_box_origin.y
                     - bounding_box_lengths.y / 2;
@@ -240,9 +241,9 @@ void OctomapFromGazeboWorld::CreateOctomap(
                   - bounding_box_lengths.x / 2;
        x < bounding_box_origin.x + bounding_box_lengths.x / 2;
        x += leaf_size) {
-    std::cout << "\rFilling closed spaces... " 
-              << 100 * (x + bounding_box_lengths.x / 2 - bounding_box_origin.x)
-                 / bounding_box_lengths.x << "%%                 ";
+    int progress = round(100 * (x + bounding_box_lengths.x / 2 
+                         - bounding_box_origin.x) / bounding_box_lengths.x);
+    std::cout << "\rFilling closed spaces... " << progress << "%              ";
 
     for (double y = leaf_size / 2 + bounding_box_origin.y 
                     - bounding_box_lengths.y / 2;


### PR DESCRIPTION
Changed the method of octomap generation to handle zero thickness walls and collisions.

It now works in 3 stages
1) Checks if a model edge exists in each cell and if it does marks it as occupied
2) Flood fills the area from the top and bottom marking all connected unknown cells as unoccupied
3) Marks all remaining unknown areas as occupied

This method has some situations where it may erroneously mark cells as filled as with walls of zero thickness it is impossible to tell if an object is meant to be solid or hollow. This method assumes all completely enclosed areas are solid.