### PR TITLE
Fixing the order of operations in stopping the recording of a rosbag

### DIFF
--- a/rotors_gazebo_plugins/src/gazebo_bag_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_bag_plugin.cpp
@@ -204,9 +204,6 @@ void GazeboBagPlugin::StartRecording() {
 }
 
 void GazeboBagPlugin::StopRecording() {
-  // Close the bag.
-  bag_.close();
-
   // Shutdown all the subscribers.
   imu_sub_.shutdown();
   wind_sub_.shutdown();
@@ -218,6 +215,9 @@ void GazeboBagPlugin::StopRecording() {
 
   // Disconnect the update event.
   event::Events::DisconnectWorldUpdateBegin(update_connection_);
+
+  // Close the bag.
+  bag_.close();
 
   // Clear the flag to show that we are not actively recording
   is_recording_ = false;


### PR DESCRIPTION
Closing the rosbag AFTER shutting down the subscribers and disconnecting the world update events.

Closing the bag first previously caused some non-fatal error messages when in verbose mode due to some callbacks still attempting to write to the bag that was already closed and also rosbag would sometimes have to be re-indexed upon use.