### PR TITLE
Use optical axis as camera reference frame

### DIFF
--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -105,7 +105,7 @@
           <cameraName>camera_${camera_suffix}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>camera_${camera_suffix}_link</frameName>
+          <frameName>camera_${camera_suffix}_optical_link</frameName>
           <hackBaseline>0.0</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>
@@ -236,7 +236,7 @@
           <cameraName>${camera_name}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-          <frameName>${camera_name}/camera_left_link</frameName>
+          <frameName>${camera_name}/camera_left_optical_link</frameName>
           <hackBaseline>${baseline_y}</hackBaseline>
           <distortionK1>0.0</distortionK1>
           <distortionK2>0.0</distortionK2>


### PR DESCRIPTION
OpenCV and other computer vision software assume a reference frame such that in an image
- z points forward
- x points right
- y points down
  This also follows the guidelines in [REP103](http://www.ros.org/reps/rep-0103.html#suffix-frames).

The optical link existed but was not used as frame of reference for the `camera_info` topic.
