### PR TITLE
Fix HIL interface compilation.

### DIFF
--- a/rotors_hil_interface/CMakeLists.txt
+++ b/rotors_hil_interface/CMakeLists.txt
@@ -5,12 +5,17 @@ add_definitions(-std=c++11)
 
 find_package(Mavlink QUIET)
 
-if(Mavlink_DIR)
+if (Mavlink_DIR)
   message(STATUS "Building HIL_INTERFACE package.")
-else()
-  message(STATUS "Mavlink not found. SKipping HIL_INTERFACE package.")
+else ()
+  message(STATUS "Mavlink not found. Skipping HIL_INTERFACE package.")
+
+  # We still have to call catkin package for this to be a valid backage,
+  # even if empty.
+  find_package(catkin REQUIRED)
+  catkin_package()
   return()
-endif()
+endif ()
 
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules


### PR DESCRIPTION
HIL interface should actually call catkin and catkin_package even if it does not build any libraries if Mavlink isn't found. This has been breaking mav_integration_test for the past few days.

http://129.132.38.183:8080/job/mav_integration_test/label=ubuntu/88/console

