### PR TITLE
Adding wind speed publishing to the wind plugin

### DIFF
--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -523,7 +523,7 @@
   <xacro:macro name="wind_plugin_macro"
     params="namespace xyz_offset wind_direction wind_force_mean
       wind_gust_direction wind_gust_duration wind_gust_start
-      wind_gust_force_mean">
+      wind_gust_force_mean wind_speed_mean">
     <gazebo>
       <plugin filename="librotors_gazebo_wind_plugin.so" name="wind_plugin">
         <frameId>world</frameId>
@@ -536,6 +536,7 @@
         <windGustDuration>${wind_gust_duration}</windGustDuration> <!-- [s] -->
         <windGustStart>${wind_gust_start}</windGustStart> <!-- [s] -->
         <windGustForceMean>${wind_gust_force_mean}</windGustForceMean> <!-- [N] -->
+        <windSpeedMean>${wind_speed_mean}</windSpeedMean> <!-- [m/s] -->
       </plugin>
     </gazebo>
   </xacro:macro>

--- a/rotors_description/urdf/mav_with_wind_gust.gazebo
+++ b/rotors_description/urdf/mav_with_wind_gust.gazebo
@@ -32,6 +32,7 @@
     wind_gust_direction="1 1 0"
     wind_gust_duration="2"
     wind_gust_start="40"
-    wind_gust_force_mean="5">
+    wind_gust_force_mean="5"
+    wind_speed_mean="0">
   </xacro:wind_plugin_macro>
 </robot>

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_bag_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_bag_plugin.h
@@ -44,6 +44,7 @@
 #include <trajectory_msgs/MultiDOFJointTrajectory.h>
 
 #include "rotors_comm/RecordRosbag.h"
+#include "rotors_comm/WindSpeed.h"
 #include "rotors_gazebo_plugins/common.h"
 
 
@@ -74,6 +75,7 @@ class GazeboBagPlugin : public ModelPlugin {
         control_attitude_thrust_topic_(mav_msgs::default_topics::COMMAND_ATTITUDE_THRUST),
         control_motor_speed_topic_(mav_msgs::default_topics::COMMAND_ACTUATORS),
         control_rate_thrust_topic_(mav_msgs::default_topics::COMMAND_RATE_THRUST),
+        wind_speed_topic_(mav_msgs::default_topics::WIND_SPEED),
         motor_topic_(mav_msgs::default_topics::MOTOR_MEASUREMENT),
         wrench_topic_(mav_msgs::default_topics::WRENCH),
         external_force_topic_(mav_msgs::default_topics::EXTERNAL_FORCE),
@@ -136,6 +138,10 @@ class GazeboBagPlugin : public ModelPlugin {
   /// \param[in] control_msg A RateThrust message from mav_msgs.
   void RateThrustCallback(const mav_msgs::RateThrustConstPtr& control_msg);
 
+  /// \brief Called when a WindSpeed message is received.
+  /// \param[in] wind_speed_msg A WindSpeed message from rotors_comm.
+  void WindSpeedCallback(const rotors_comm::WindSpeedConstPtr& wind_speed_msg);
+
   /// \brief Log the ground truth pose and twist.
   /// \param[in] now The current gazebo common::Time
   void LogGroundTruth(const common::Time now);
@@ -180,6 +186,7 @@ class GazeboBagPlugin : public ModelPlugin {
   std::string control_attitude_thrust_topic_;
   std::string control_motor_speed_topic_;
   std::string control_rate_thrust_topic_;
+  std::string wind_speed_topic_;
   std::string wrench_topic_;
   std::string motor_topic_;
   std::string frame_id_;
@@ -207,6 +214,7 @@ class GazeboBagPlugin : public ModelPlugin {
   ros::Subscriber control_attitude_thrust_sub_;
   ros::Subscriber control_motor_speed_sub_;
   ros::Subscriber control_rate_thrust_sub_;
+  ros::Subscriber wind_speed_sub_;
   ros::Subscriber command_pose_sub_;
 
   // Ros service server

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_bag_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_bag_plugin.h
@@ -76,7 +76,7 @@ class GazeboBagPlugin : public ModelPlugin {
         control_rate_thrust_topic_(mav_msgs::default_topics::COMMAND_RATE_THRUST),
         motor_topic_(mav_msgs::default_topics::MOTOR_MEASUREMENT),
         wrench_topic_(mav_msgs::default_topics::WRENCH),
-        wind_topic_(mav_msgs::default_topics::WIND),
+        external_force_topic_(mav_msgs::default_topics::EXTERNAL_FORCE),
         waypoint_topic_(mav_msgs::default_topics::COMMAND_TRAJECTORY),
         command_pose_topic_(mav_msgs::default_topics::COMMAND_POSE),
         //---------------
@@ -112,9 +112,9 @@ class GazeboBagPlugin : public ModelPlugin {
   /// \param[in] imu_msg A IMU message from sensor_msgs.
   void ImuCallback(const sensor_msgs::ImuConstPtr& imu_msg);
 
-  /// \brief Called when an Wind message is received.
-  /// \param[in] wind_msg A WrenchStamped message from geometry_msgs.
-  void WindCallback(const geometry_msgs::WrenchStampedConstPtr& wind_msg);
+  /// \brief Called when an WrenchStamped message is received.
+  /// \param[in] force_msg A WrenchStamped message from geometry_msgs.
+  void ExternalForceCallback(const geometry_msgs::WrenchStampedConstPtr& force_msg);
 
   /// \brief Called when a MultiDOFJointTrajectoryPoint message is received.
   /// \param[in] trajectory_msg A MultiDOFJointTrajectoryPoint message from trajectory_msgs.
@@ -174,7 +174,7 @@ class GazeboBagPlugin : public ModelPlugin {
   std::string ground_truth_pose_topic_;
   std::string ground_truth_twist_topic_;
   std::string imu_topic_;
-  std::string wind_topic_;
+  std::string external_force_topic_;
   std::string waypoint_topic_;
   std::string command_pose_topic_;
   std::string control_attitude_thrust_topic_;
@@ -202,7 +202,7 @@ class GazeboBagPlugin : public ModelPlugin {
 
   // Ros subscribers
   ros::Subscriber imu_sub_;
-  ros::Subscriber wind_sub_;
+  ros::Subscriber external_force_sub_;
   ros::Subscriber waypoint_sub_;
   ros::Subscriber control_attitude_thrust_sub_;
   ros::Subscriber control_motor_speed_sub_;

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
@@ -72,7 +72,7 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
       : ModelPlugin(),
         MotorModel(),
         command_sub_topic_(mav_msgs::default_topics::COMMAND_ACTUATORS),
-        wind_speed_sub_topic_(mav_msgs::default_topics::WIND),
+        wind_speed_sub_topic_(mav_msgs::default_topics::WIND_SPEED),
         motor_speed_pub_topic_(mav_msgs::default_topics::MOTOR_MEASUREMENT),
         motor_number_(0),
         turning_direction_(turning_direction::CW),

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_ros_interface_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_ros_interface_plugin.h
@@ -266,6 +266,11 @@ class GazeboRosInterfacePlugin : public WorldPlugin {
                                  ros::Publisher ros_publisher);
   geometry_msgs::TwistStamped ros_twist_stamped_msg_;
 
+  // WIND SPEED
+  void GzWindSpeedMsgCallback(GzWindSpeedMsgPtr& gz_wind_speed_msg,
+                              ros::Publisher ros_publisher);
+  rotors_comm::WindSpeed ros_wind_speed_msg_;
+
   // WRENCH STAMPED
   void GzWrenchStampedMsgCallback(GzWrenchStampedMsgPtr& gz_wrench_stamped_msg,
                                   ros::Publisher ros_publisher);

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
@@ -35,7 +35,7 @@
 #include "rotors_gazebo_plugins/common.h"
 
 #include "WindSpeed.pb.h"             // Wind speed message
-#include "WrenchStamped.pb.h"         // Wind message
+#include "WrenchStamped.pb.h"         // Wind force message
 
 namespace gazebo {
 // Default values
@@ -67,8 +67,8 @@ class GazeboWindPlugin : public ModelPlugin {
   GazeboWindPlugin()
       : ModelPlugin(),
         namespace_(kDefaultNamespace),
-        wind_pub_topic_(mav_msgs::default_topics::WIND),
-        wind_speed_pub_topic_(kDefaultWindSpeedPubTopic),
+        wind_force_pub_topic_(mav_msgs::default_topics::EXTERNAL_FORCE),
+        wind_speed_pub_topic_(mav_msgs::default_topics::WIND_SPEED),
         wind_force_mean_(kDefaultWindForceMean),
         wind_force_variance_(kDefaultWindForceVariance),
         wind_gust_force_mean_(kDefaultWindGustForceMean),
@@ -118,7 +118,7 @@ class GazeboWindPlugin : public ModelPlugin {
 
   std::string frame_id_;
   std::string link_name_;
-  std::string wind_pub_topic_;
+  std::string wind_force_pub_topic_;
   std::string wind_speed_pub_topic_;
 
   double wind_force_mean_;
@@ -135,7 +135,7 @@ class GazeboWindPlugin : public ModelPlugin {
   common::Time wind_gust_end_;
   common::Time wind_gust_start_;
 
-  gazebo::transport::PublisherPtr wind_pub_;
+  gazebo::transport::PublisherPtr wind_force_pub_;
   gazebo::transport::PublisherPtr wind_speed_pub_;
 
   gazebo::transport::NodePtr node_handle_;

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
@@ -34,7 +34,7 @@
 
 #include "rotors_gazebo_plugins/common.h"
 
-#include "TwistStamped.pb.h"          // Wind speed message
+#include "WindSpeed.pb.h"             // Wind speed message
 #include "WrenchStamped.pb.h"         // Wind message
 
 namespace gazebo {
@@ -73,6 +73,8 @@ class GazeboWindPlugin : public ModelPlugin {
         wind_force_variance_(kDefaultWindForceVariance),
         wind_gust_force_mean_(kDefaultWindGustForceMean),
         wind_gust_force_variance_(kDefaultWindGustForceVariance),
+        wind_speed_mean_(kDefaultWindSpeedMean),
+        wind_speed_variance_(kDefaultWindSpeedVariance),
         wind_direction_(kDefaultWindDirection),
         wind_gust_direction_(kDefaultWindGustDirection),
         frame_id_(kDefaultFrameId),
@@ -146,7 +148,7 @@ class GazeboWindPlugin : public ModelPlugin {
   /// \brief    Gazebo message for sending wind speed data.
   /// \details  This is defined at the class scope so that it is re-created
   ///           everytime a wind speed message needs to be sent, increasing performance.
-  gz_geometry_msgs::TwistStamped twist_stamped_msg_;
+  gz_mav_msgs::WindSpeed wind_speed_msg_;
 };
 }
 

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_wind_plugin.h
@@ -34,12 +34,14 @@
 
 #include "rotors_gazebo_plugins/common.h"
 
+#include "TwistStamped.pb.h"          // Wind speed message
 #include "WrenchStamped.pb.h"         // Wind message
 
 namespace gazebo {
 // Default values
 static const std::string kDefaultFrameId = "world";
 static const std::string kDefaultLinkName = "base_link";
+static const std::string kDefaultWindSpeedPubTopic = "wind_speed";
 
 static constexpr double kDefaultWindForceMean = 0.0;
 static constexpr double kDefaultWindForceVariance = 0.0;
@@ -48,6 +50,9 @@ static constexpr double kDefaultWindGustForceVariance = 0.0;
 
 static constexpr double kDefaultWindGustStart = 10.0;
 static constexpr double kDefaultWindGustDuration = 0.0;
+
+static constexpr double kDefaultWindSpeedMean = 0.0;
+static constexpr double kDefaultWindSpeedVariance = 0.0;
 
 static const math::Vector3 kDefaultWindDirection = math::Vector3(1, 0, 0);
 static const math::Vector3 kDefaultWindGustDirection = math::Vector3(0, 1, 0);
@@ -63,6 +68,7 @@ class GazeboWindPlugin : public ModelPlugin {
       : ModelPlugin(),
         namespace_(kDefaultNamespace),
         wind_pub_topic_(mav_msgs::default_topics::WIND),
+        wind_speed_pub_topic_(kDefaultWindSpeedPubTopic),
         wind_force_mean_(kDefaultWindForceMean),
         wind_force_variance_(kDefaultWindForceVariance),
         wind_gust_force_mean_(kDefaultWindGustForceMean),
@@ -111,11 +117,14 @@ class GazeboWindPlugin : public ModelPlugin {
   std::string frame_id_;
   std::string link_name_;
   std::string wind_pub_topic_;
+  std::string wind_speed_pub_topic_;
 
   double wind_force_mean_;
   double wind_force_variance_;
   double wind_gust_force_mean_;
   double wind_gust_force_variance_;
+  double wind_speed_mean_;
+  double wind_speed_variance_;
 
   math::Vector3 xyz_offset_;
   math::Vector3 wind_direction_;
@@ -125,14 +134,19 @@ class GazeboWindPlugin : public ModelPlugin {
   common::Time wind_gust_start_;
 
   gazebo::transport::PublisherPtr wind_pub_;
+  gazebo::transport::PublisherPtr wind_speed_pub_;
 
   gazebo::transport::NodePtr node_handle_;
 
   /// \brief    Gazebo message for sending wind data.
-  /// \details  This is defined at the class scope so that it so re-created
+  /// \details  This is defined at the class scope so that it is re-created
   ///           everytime a wind message needs to be sent, increasing performance.
   gz_geometry_msgs::WrenchStamped wrench_stamped_msg_;
 
+  /// \brief    Gazebo message for sending wind speed data.
+  /// \details  This is defined at the class scope so that it is re-created
+  ///           everytime a wind speed message needs to be sent, increasing performance.
+  gz_geometry_msgs::TwistStamped twist_stamped_msg_;
 };
 }
 

--- a/rotors_gazebo_plugins/msgs/ConnectGazeboToRosTopic.proto
+++ b/rotors_gazebo_plugins/msgs/ConnectGazeboToRosTopic.proto
@@ -27,7 +27,8 @@ message ConnectGazeboToRosTopic
     TRANSFORM_STAMPED = 9;
     TWIST_STAMPED = 10;
     VECTOR_3D_STAMPED = 11;
-    WRENCH_STAMPED = 12;
+    WIND_SPEED = 12;
+    WRENCH_STAMPED = 13;
   }
   required MsgType msgType = 4;
 }

--- a/rotors_gazebo_plugins/src/gazebo_bag_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_bag_plugin.cpp
@@ -89,8 +89,10 @@ void GazeboBagPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
                            ground_truth_pose_topic_);
   getSdfParam<std::string>(_sdf, "twistTopic", ground_truth_twist_topic_,
                            ground_truth_twist_topic_);
-  getSdfParam<std::string>(_sdf, "wrenchesTopic", wrench_topic_, wrench_topic_);
-  getSdfParam<std::string>(_sdf, "windTopic", wind_topic_, wind_topic_);
+  getSdfParam<std::string>(_sdf, "wrenchesTopic", wrench_topic_,
+                           wrench_topic_);
+  getSdfParam<std::string>(_sdf, "externalForceTopic", external_force_topic_,
+                           external_force_topic_);
   getSdfParam<std::string>(_sdf, "waypointTopic", waypoint_topic_,
                            waypoint_topic_);
   getSdfParam<std::string>(_sdf, "commandPoseTopic", command_pose_topic_,
@@ -184,9 +186,9 @@ void GazeboBagPlugin::StartRecording() {
   imu_sub_ = node_handle_->subscribe(imu_topic_, 10,
                                      &GazeboBagPlugin::ImuCallback, this);
 
-  // Subscriber to Wind WrenchStamped Message.
-  wind_sub_ = node_handle_->subscribe(wind_topic_, 10,
-                                      &GazeboBagPlugin::WindCallback, this);
+  // Subscriber to External Force WrenchStamped Message.
+  external_force_sub_ = node_handle_->subscribe(external_force_topic_, 10,
+      &GazeboBagPlugin::ExternalForceCallback, this);
 
   // Subscriber to Waypoint MultiDOFJointTrajectory Message.
   waypoint_sub_ = node_handle_->subscribe(
@@ -226,7 +228,7 @@ void GazeboBagPlugin::StartRecording() {
 void GazeboBagPlugin::StopRecording() {
   // Shutdown all the subscribers.
   imu_sub_.shutdown();
-  wind_sub_.shutdown();
+  external_force_sub_.shutdown();
   waypoint_sub_.shutdown();
   command_pose_sub_.shutdown();
   control_attitude_thrust_sub_.shutdown();
@@ -251,11 +253,11 @@ void GazeboBagPlugin::ImuCallback(const sensor_msgs::ImuConstPtr& imu_msg) {
   writeBag(namespace_ + "/" + imu_topic_, ros_now, imu_msg);
 }
 
-void GazeboBagPlugin::WindCallback(
-    const geometry_msgs::WrenchStampedConstPtr& wind_msg) {
+void GazeboBagPlugin::ExternalForceCallback(
+    const geometry_msgs::WrenchStampedConstPtr& force_msg) {
   common::Time now = world_->GetSimTime();
   ros::Time ros_now = ros::Time(now.sec, now.nsec);
-  writeBag(namespace_ + "/" + wind_topic_, ros_now, wind_msg);
+  writeBag(namespace_ + "/" + external_force_topic_, ros_now, force_msg);
 }
 
 void GazeboBagPlugin::WaypointCallback(

--- a/rotors_gazebo_plugins/src/gazebo_ros_interface_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_ros_interface_plugin.cpp
@@ -251,6 +251,12 @@ void GazeboRosInterfacePlugin::GzConnectGazeboToRosTopicMsgCallback(
           &GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback, this,
           gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
       break;
+    case gz_std_msgs::ConnectGazeboToRosTopic::WIND_SPEED:
+      ConnectHelper<gz_mav_msgs::WindSpeed,
+                    rotors_comm::WindSpeed>(
+          &GazeboRosInterfacePlugin::GzWindSpeedMsgCallback, this,
+          gazeboNamespace, gazeboTopicName, rosTopicName, gz_node_handle_);
+      break;
     case gz_std_msgs::ConnectGazeboToRosTopic::WRENCH_STAMPED:
       ConnectHelper<gz_geometry_msgs::WrenchStamped,
                     geometry_msgs::WrenchStamped>(
@@ -801,6 +807,27 @@ void GazeboRosInterfacePlugin::GzVector3dStampedMsgCallback(
   ros_position_stamped_msg_.point.z = gz_vector_3d_stamped_msg->position().z();
 
   ros_publisher.publish(ros_position_stamped_msg_);
+}
+
+void GazeboRosInterfacePlugin::GzWindSpeedMsgCallback(
+    GzWindSpeedMsgPtr& gz_wind_speed_msg,
+    ros::Publisher ros_publisher) {
+  // ============================================ //
+  // =================== HEADER ================= //
+  // ============================================ //
+  ConvertHeaderGzToRos(gz_wind_speed_msg->header(),
+                       &ros_wind_speed_msg_.header);
+
+  // ============================================ //
+  // ================== VELOCITY ================ //
+  // ============================================ //
+  ros_wind_speed_msg_.velocity.x =
+      gz_wind_speed_msg->velocity().x();
+  ros_wind_speed_msg_.velocity.y =
+      gz_wind_speed_msg->velocity().y();
+  ros_wind_speed_msg_.velocity.z =
+      gz_wind_speed_msg->velocity().z();
+  ros_publisher.publish(ros_wind_speed_msg_);
 }
 
 void GazeboRosInterfacePlugin::GzWrenchStampedMsgCallback(

--- a/rotors_gazebo_plugins/src/gazebo_wind_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_wind_plugin.cpp
@@ -50,10 +50,10 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   else
     gzerr << "[gazebo_wind_plugin] Please specify a robotNamespace.\n";
 
-  // Create Gazebo Node
+  // Create Gazebo Node.
   node_handle_ = gazebo::transport::NodePtr(new transport::Node());
 
-  // Initisalise with default namespace (typically /gazebo/default/)
+  // Initisalise with default namespace (typically /gazebo/default/).
   node_handle_->Init();
 
   if (_sdf->HasElement("xyzOffset"))
@@ -61,8 +61,8 @@ void GazeboWindPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
   else
     gzerr << "[gazebo_wind_plugin] Please specify a xyzOffset.\n";
 
-  getSdfParam<std::string>(_sdf, "windPubTopic", wind_pub_topic_,
-                           wind_pub_topic_);
+  getSdfParam<std::string>(_sdf, "windForcePubTopic", wind_force_pub_topic_,
+                           wind_force_pub_topic_);
   getSdfParam<std::string>(_sdf, "windSpeedPubTopic", wind_speed_pub_topic_,
                            wind_speed_pub_topic_);
   getSdfParam<std::string>(_sdf, "frameId", frame_id_, frame_id_);
@@ -151,9 +151,9 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
   wrench_stamped_msg_.mutable_wrench()->mutable_torque()->set_y(0);
   wrench_stamped_msg_.mutable_wrench()->mutable_torque()->set_z(0);
 
-  wind_pub_->Publish(wrench_stamped_msg_);
+  wind_force_pub_->Publish(wrench_stamped_msg_);
 
-  // Calculate the wind speed
+  // Calculate the wind speed.
   double wind_speed = wind_speed_mean_;
   math::Vector3 wind_velocity = wind_speed * wind_direction_;
 
@@ -169,7 +169,7 @@ void GazeboWindPlugin::OnUpdate(const common::UpdateInfo& _info) {
 }
 
 void GazeboWindPlugin::CreatePubsAndSubs() {
-  // Create temporary "ConnectGazeboToRosTopic" publisher and message
+  // Create temporary "ConnectGazeboToRosTopic" publisher and message.
   gazebo::transport::PublisherPtr connect_gazebo_to_ros_topic_pub =
       node_handle_->Advertise<gz_std_msgs::ConnectGazeboToRosTopic>(
           "~/" + kConnectGazeboToRosSubtopic, 1);
@@ -179,14 +179,14 @@ void GazeboWindPlugin::CreatePubsAndSubs() {
   // ============================================ //
   // ========= WRENCH STAMPED MSG SETUP ========= //
   // ============================================ //
-  wind_pub_ = node_handle_->Advertise<gz_geometry_msgs::WrenchStamped>(
-      "~/" + namespace_ + "/" + wind_pub_topic_, 1);
+  wind_force_pub_ = node_handle_->Advertise<gz_geometry_msgs::WrenchStamped>(
+      "~/" + namespace_ + "/" + wind_force_pub_topic_, 1);
 
   // connect_gazebo_to_ros_topic_msg.set_gazebo_namespace(namespace_);
   connect_gazebo_to_ros_topic_msg.set_gazebo_topic("~/" + namespace_ + "/" +
-                                                   wind_pub_topic_);
+                                                   wind_force_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_ros_topic(namespace_ + "/" +
-                                                wind_pub_topic_);
+                                                wind_force_pub_topic_);
   connect_gazebo_to_ros_topic_msg.set_msgtype(
       gz_std_msgs::ConnectGazeboToRosTopic::WRENCH_STAMPED);
   connect_gazebo_to_ros_topic_pub->Publish(connect_gazebo_to_ros_topic_msg,

--- a/rotors_gazebo_plugins/src/gazebo_wind_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_wind_plugin.cpp
@@ -156,7 +156,7 @@ void GazeboWindPlugin::CreatePubsAndSubs() {
   gz_std_msgs::ConnectGazeboToRosTopic connect_gazebo_to_ros_topic_msg;
 
   // ============================================ //
-  // =========== NAV SAT FIX MSG SETUP ========== //
+  // ========= WRENCH STAMPED MSG SETUP ========= //
   // ============================================ //
   wind_pub_ = node_handle_->Advertise<gz_geometry_msgs::WrenchStamped>(
       "~/" + namespace_ + "/" + wind_pub_topic_, 1);


### PR DESCRIPTION
Adding the ability to publish the user-set wind speed to the wind plugin. This is in preparation for adding the fixed-wing aerodynamics plugin soon, and also the motor model plugin currently already has a listener for wind speed messages.

The reason for "DO NOT MERGE" for now is that I found a small problem while testing this - the 'motor_model' plugin currently has "mav_msgs::default_topics::WIND" as the default value for wind speed subscription topic with message type WIND_SPEED ... the 'wind' plugin, in its already-existing implementation, also has "mav_msgs::default_topics::WIND" as the default value BUT for the wind force publishing topic with message type WRENCH_STAMPED.

Currently, the wind plugin has a strange way of generating the default pub topic (below) that results in namespace appearing twice and no slash between last namespace and 'wind'.

````
getSdfParam<std::string>(_sdf, "windPubTopic", wind_pub_topic_,
                           "/" + namespace_ + wind_pub_topic_);

...

wind_pub_ = node_handle_->Advertise<gz_geometry_msgs::WrenchStamped>(
      "~/" + namespace_ + "/" + wind_pub_topic_, 1);
````

Once it is cleaned up to the code below, the problem mentioned earlier arises.

`getSdfParam<std::string>(_sdf, "windPubTopic", wind_pub_topic_,
                           wind_pub_topic_);`

What do you think of adding a 'wind_speed' topic to mav_msgs::default_topics in order to differentiate between wind speed and wind force topics, not only for the sake of this case, but for overall clarity? ... If we do this then I'll do that first before adapting and merging this pull request.