### PR TITLE
[WIP] Add px4 support to rotors

### DIFF
--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -32,7 +32,7 @@
         <linkName>${namespace}/base_link</linkName>
         <frameId>${namespace}/base_link</frameId>
         <rotorVelocitySlowdownSim>${rotor_velocity_slowdown_sim}</rotorVelocitySlowdownSim>
-	<waitToRecordBag>${wait_to_record_bag}</waitToRecordBag>
+        <waitToRecordBag>${wait_to_record_bag}</waitToRecordBag>
       </plugin>
     </gazebo>
   </xacro:macro>
@@ -266,8 +266,8 @@
   <!-- ==================== ROS INTERFACE MACRO ====================== -->
   <!-- =============================================================== -->
   <!-- <xacro:macro 
-  		name="ros_interface_plugin_macro"
-  		params="namespace">
+        name="ros_interface_plugin_macro"
+        params="namespace">
     <gazebo>
       <plugin name="ros_interface_plugin" filename="librotors_gazebo_ros_interface_plugin.so">
         <robotNamespace>${namespace}</robotNamespace>
@@ -284,24 +284,120 @@
       reference_magnetic_field_east reference_magnetic_field_down reference_latitude 
       reference_longitude reference_altitude">
     <gazebo>
-      <plugin name="mavlink_interface" filename="librotors_gazebo_mavlink_interface.so">
+      <plugin name='mavlink_interface' filename='librotors_gazebo_mavlink_interface.so'>
         <robotNamespace>${namespace}</robotNamespace>
-	<mavlinkControlSubTopic>${mavlink_sub_topic}</mavlinkControlSubTopic>
         <imuSubTopic>${imu_sub_topic}</imuSubTopic>
-        <mavlinkHilSensorPubTopic>${mavlink_pub_topic}</mavlinkHilSensorPubTopic>
-	<motorSpeedsPubTopic>${motors_speeds_pub_topic}</motorSpeedsPubTopic>
-	<gpsUpdateFreq>${gps_update_freq}</gpsUpdateFreq> <!-- Frequency of HIL GPS messages [Hz] -->
-	<rotorCount>${rotor_count}</rotorCount>
-        <!-- [Gauss] Below are the North, East, and Down components of the Earth's magnetic field at the reference location.
-             The default reference location is Zurich (lat=+47.3667degN, lon=+8.5500degE, h=+500m, WGS84).
-	     You can obtain the magnetic field strength for your location using the World Magnetic Model: 
-             https://www.ngdc.noaa.gov/geomag/WMM/calculators.shtml -->
-        <referenceMagNorth>${reference_magnetic_field_north}</referenceMagNorth>
-        <referenceMagEast>${reference_magnetic_field_east}</referenceMagEast>
-        <referenceMagDown>${reference_magnetic_field_down}</referenceMagDown>
-	<referenceLatitude>${reference_latitude}</referenceLatitude> <!-- the initial latitude [degrees [-90, 90]] -->
-        <referenceLongitude>${reference_longitude}</referenceLongitude> <!-- the initial longitude [degrees [-180, 180]] -->
-        <referenceAltitude>${reference_altitude}</referenceAltitude> <!-- the initial altitude [m] -->
+        <!--These are nolonger used?-->
+        <!--<mavlinkControlSubTopic>${mavlink_sub_topic}</mavlinkControlSubTopic>-->
+        <!--<mavlinkHilSensorPubTopic>${mavlink_pub_topic}</mavlinkHilSensorPubTopic>-->
+        <!--<motorSpeedsPubTopic>${motors_speeds_pub_topic}</motorSpeedsPubTopic>-->
+        <!--<gpsUpdateFreq>${gps_update_freq}</gpsUpdateFreq> [> Frequency of HIL GPS messages [Hz] <]-->
+        <!--<rotorCount>${rotor_count}</rotorCount>-->
+        <!--<referenceMagNorth>${reference_magnetic_field_north}</referenceMagNorth>-->
+        <!--<referenceMagEast>${reference_magnetic_field_east}</referenceMagEast>-->
+        <!--<referenceMagDown>${reference_magnetic_field_down}</referenceMagDown>-->
+        <!--<referenceLatitude>${reference_latitude}</referenceLatitude> [> the initial latitude [degrees [-90, 90]] <]-->
+        <!--<referenceLongitude>${reference_longitude}</referenceLongitude> [> the initial longitude [degrees [-180, 180]] <]-->
+        <!--<referenceAltitude>${reference_altitude}</referenceAltitude> [> the initial altitude [m] <]-->
+        <mavlink_addr>INADDR_ANY</mavlink_addr>
+        <mavlink_udp_port>14560</mavlink_udp_port>
+        <motorSpeedCommandPubTopic>/gazebo/command/motor_speed</motorSpeedCommandPubTopic>
+        <control_channels>
+          <channel name='rotor1'>
+            <input_index>0</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>100</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+          </channel>
+          <channel name='rotor2'>
+            <input_index>1</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>100</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+          </channel>
+          <channel name='rotor3'>
+            <input_index>2</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>100</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+          </channel>
+          <channel name='rotor4'>
+            <input_index>3</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>1000</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>100</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+          </channel>
+          <channel name='rotor5'>
+            <input_index>4</input_index>
+            <input_offset>1</input_offset>
+            <input_scaling>324.6</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>velocity</joint_control_type>
+            <joint_control_pid>
+              <p>0.1</p>
+              <i>0</i>
+              <d>0</d>
+              <iMax>0.0</iMax>
+              <iMin>0.0</iMin>
+              <cmdMax>2</cmdMax>
+              <cmdMin>-2</cmdMin>
+            </joint_control_pid>
+            <joint_name>zephyr_delta_wing::propeller_joint</joint_name>
+          </channel>
+          <channel name='rotor6'>
+            <input_index>5</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>0.524</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position</joint_control_type>
+            <joint_name>zephyr_delta_wing::flap_left_joint</joint_name>
+            <joint_control_pid>
+              <p>10.0</p>
+              <i>0</i>
+              <d>0</d>
+              <iMax>0</iMax>
+              <iMin>0</iMin>
+              <cmdMax>20</cmdMax>
+              <cmdMin>-20</cmdMin>
+            </joint_control_pid>
+          </channel>
+          <channel name='rotor7'>
+            <input_index>6</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>0.524</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position</joint_control_type>
+            <joint_name>zephyr_delta_wing::flap_right_joint</joint_name>
+            <joint_control_pid>
+              <p>10.0</p>
+              <i>0</i>
+              <d>0</d>
+              <iMax>0</iMax>
+              <iMin>0</iMin>
+              <cmdMax>20</cmdMax>
+              <cmdMin>-20</cmdMin>
+            </joint_control_pid>
+          </channel>
+          <channel name='rotor8'>
+            <input_index>7</input_index>
+            <input_offset>0</input_offset>
+            <input_scaling>0.524</input_scaling>
+            <zero_position_disarmed>0</zero_position_disarmed>
+            <zero_position_armed>0</zero_position_armed>
+            <joint_control_type>position</joint_control_type>
+          </channel>
+        </control_channels>
       </plugin>
     </gazebo>
   </xacro:macro>
@@ -508,7 +604,7 @@
         <magnetometerTopic>${magnetometer_topic}</magnetometerTopic> <!-- (string): name of the sensor output topic and prefix of service names (defaults to 'magnetic_field') -->
         <!-- [Tesla] Below is the reference Earth's magnetic field at the reference location in NED frame.
              The default reference location is Zurich (lat=+47.3667degN, lon=+8.5500degE, h=+500m, WGS84).
-	     You can obtain the magnetic field strength for your location using the World Magnetic Model: 
+         You can obtain the magnetic field strength for your location using the World Magnetic Model: 
              http://www.ngdc.noaa.gov/geomag-web/#igrfwmm -->
         <refMagNorth>${ref_mag_north}</refMagNorth>
         <refMagEast>${ref_mag_east}</refMagEast>

--- a/rotors_gazebo/launch/firefly_swarm_hovering_example.launch
+++ b/rotors_gazebo/launch/firefly_swarm_hovering_example.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="mav_name" default="firefly" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/fixed_wing.launch
+++ b/rotors_gazebo/launch/fixed_wing.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="$(arg uav_name)"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/launch/fixed_wing_with_joy.launch
+++ b/rotors_gazebo/launch/fixed_wing_with_joy.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="$(arg uav_name)"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/launch/mav.launch
+++ b/rotors_gazebo/launch/mav.launch
@@ -3,6 +3,7 @@
   <arg name="world_name" default="basic"/>
   <arg name="enable_logging" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="log_file" default="$(arg mav_name)"/>
   <arg name="debug" default="false"/>
   <arg name="gui" default="true"/>
@@ -11,8 +12,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <arg name="debug" value="$(arg debug)" />
@@ -27,6 +26,7 @@
       <arg name="model" value="$(find rotors_description)/urdf/$(arg mav_name)_base.xacro" />
       <arg name="enable_logging" value="$(arg enable_logging)" />
       <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+      <arg name="enable_mavlink_interface" value="$(arg enable_mavlink_interface)" />
       <arg name="log_file" value="$(arg log_file)"/>
     </include>
   </group>

--- a/rotors_gazebo/launch/mav_hovering_example.launch
+++ b/rotors_gazebo/launch/mav_hovering_example.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/mav_hovering_example_with_vi_sensor.launch
+++ b/rotors_gazebo/launch/mav_hovering_example_with_vi_sensor.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_powerplant_with_waypoint_publisher.launch
+++ b/rotors_gazebo/launch/mav_powerplant_with_waypoint_publisher.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/powerplant.world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_joy.launch
+++ b/rotors_gazebo/launch/mav_with_joy.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_keyboard.launch
+++ b/rotors_gazebo/launch/mav_with_keyboard.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_px4.launch
+++ b/rotors_gazebo/launch/mav_with_px4.launch
@@ -1,0 +1,65 @@
+<launch>
+  <arg name="mav_name" default="iris"/>
+  <arg name="world_name" default="basic"/>
+  <arg name="enable_logging" default="false"/>
+  <arg name="enable_ground_truth" default="true"/>
+  <arg name="log_file" default="$(arg mav_name)"/>
+  <arg name="debug" default="false"/>
+  <arg name="gui" default="true"/>
+  <arg name="paused" default="true"/>
+  <!-- The following line causes gzmsg and gzerr messages to be printed to the console
+      (even when Gazebo is started through roslaunch) -->
+  <arg name="verbose" default="false"/>
+
+  <!--px4 args-->
+  <arg name="est" default="ekf2"/>
+  <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg mav_name)"/>
+  <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+  <arg name="gcs_url" default=""/> <!-- GCS link is provided by SITL -->
+  <arg name="tgt_system" default="1" />
+  <arg name="tgt_component" default="1" />
+  <arg name="pluginlists_yaml" default="$(find mavros)/launch/px4_pluginlists.yaml" />
+  <arg name="config_yaml" default="$(find mavros)/launch/px4_config.yaml" />
+
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
+    <arg name="debug" value="$(arg debug)" />
+    <arg name="paused" value="$(arg paused)" />
+    <arg name="gui" value="$(arg gui)" />
+    <arg name="verbose" value="$(arg verbose)"/>
+  </include>
+
+  <group ns="/">
+
+    <!--rotors sim-->
+    <!--<include file="$(find rotors_gazebo)/launch/spawn_mav.launch">-->
+      <!--<arg name="mav_name" value="$(arg mav_name)" />-->
+      <!--<arg name="model" value="$(find rotors_description)/urdf/$(arg mav_name)_base.xacro" />-->
+      <!--<arg name="enable_logging" value="$(arg enable_logging)" />-->
+      <!--<arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />-->
+      <!--<arg name="enable_mavlink_interface" value="true" />-->
+      <!--<arg name="log_file" value="$(arg log_file)"/>-->
+    <!--</include>-->
+
+    <arg name="sdf" default="$(find rotors_gazebo)/models/iris/iris.sdf"/>
+
+    <node name="$(anon vehicle_spawn)" output="screen" pkg="gazebo_ros" type="spawn_model"
+        args="-sdf -file $(arg sdf) -model iris"/>
+
+    <!--PX4 posix SITL-->
+    <node name="px4" pkg="px4" type="px4" args="$(find px4) $(arg rcS)"
+      output="screen"/>
+
+    <!-- MAVROS launch script PX4 (default) -->
+    <include file="$(find mavros)/launch/node.launch">
+        <arg name="pluginlists_yaml" value="$(arg pluginlists_yaml)" />
+        <arg name="config_yaml" value="$(arg config_yaml)" />
+        <arg name="fcu_url" value="$(arg fcu_url)" />
+        <arg name="gcs_url" value="$(arg gcs_url)" />
+        <arg name="tgt_system" value="$(arg tgt_system)" />
+        <arg name="tgt_component" value="$(arg tgt_component)" />
+    </include>
+
+  </group>
+
+</launch>

--- a/rotors_gazebo/launch/mav_with_waypoint_publisher.launch
+++ b/rotors_gazebo/launch/mav_with_waypoint_publisher.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_wind_gust.launch
+++ b/rotors_gazebo/launch/mav_with_wind_gust.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="$(arg mav_name)"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/launch/mavros.launch
+++ b/rotors_gazebo/launch/mavros.launch
@@ -1,0 +1,25 @@
+<launch>
+    <!-- MAVROS launch script PX4 (default) -->
+
+    <arg name="ns" default="/" />
+    <arg name="fcu_url" default="" />
+    <arg name="gcs_url" default="udp://:14550@:14555" />
+    <arg name="tgt_system" default="1" />
+    <arg name="tgt_component" default="1" />
+    <arg name="pluginlists_yaml" default="$(find mavros)/launch/px4_pluginlists.yaml" />
+    <arg name="config_yaml" default="$(find mavros)/launch/px4_config.yaml" />
+
+    <group ns="$(arg ns)">
+        <include file="$(find mavros)/launch/node.launch">
+            <arg name="pluginlists_yaml" value="$(arg pluginlists_yaml)" />
+            <arg name="config_yaml" value="$(arg config_yaml)" />
+
+            <arg name="fcu_url" value="$(arg fcu_url)" />
+            <arg name="gcs_url" value="$(arg gcs_url)" />
+            <arg name="tgt_system" value="$(arg tgt_system)" />
+            <arg name="tgt_component" value="$(arg tgt_component)" />
+        </include>
+    </group>
+</launch>
+
+<!-- vim: set ft=xml et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->

--- a/rotors_gazebo/launch/mavros_posix_sitl.launch
+++ b/rotors_gazebo/launch/mavros_posix_sitl.launch
@@ -1,0 +1,59 @@
+<launch>
+
+    <!-- MAVROS posix SITL environment launch script -->
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+    <arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0"/>
+
+
+    <arg name="est" default="lpe"/>
+    <arg name="vehicle" default="iris"/>
+    <arg name="world" default="$(find rotors_gazebo)/worlds/empty.world"/>
+    <arg name="sdf" default="$(find rotors_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf"/>
+
+    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
+
+    <arg name="headless" default="false"/>
+    <arg name="gui" default="true"/>
+    <arg name="ns" default="/"/>
+    <arg name="fcu_url" default="udp://:14540@localhost:14557"/>
+
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+
+    <arg name="pluginlists_yaml" default="$(find mavros)/launch/px4_pluginlists.yaml" />
+    <arg name="config_yaml" default="$(find mavros)/launch/px4_config.yaml" />
+
+    <include file="$(find rotors_gazebo)/launch/posix_sitl.launch">
+        <arg name="x" value="$(arg x)"/>
+        <arg name="y" value="$(arg y)"/>
+        <arg name="z" value="$(arg z)"/>
+        <arg name="R" value="$(arg R)"/>
+        <arg name="P" value="$(arg P)"/>
+        <arg name="Y" value="$(arg Y)"/>
+        <arg name="world" value="$(arg world)"/>
+        <arg name="vehicle" value="$(arg vehicle)"/>
+        <arg name="sdf" value="$(arg sdf)"/>
+        <arg name="rcS" value="$(arg rcS)"/>
+        <arg name="headless" value="$(arg headless)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="ns" value="$(arg ns)"/>
+        <arg name="debug" value="$(arg debug)"/>
+        <arg name="verbose" value="$(arg verbose)"/>
+        <arg name="paused" value="$(arg paused)"/>
+    </include>
+
+    <include file="$(find rotors_gazebo)/launch/mavros.launch">
+        <arg name="ns" value="$(arg ns)"/>
+        <arg name="gcs_url" value=""/> <!-- GCS link is provided by SITL -->
+        <arg name="fcu_url" value="$(arg fcu_url)"/>
+        <arg name="pluginlists_yaml" value="$(arg pluginlists_yaml)" />
+        <arg name="config_yaml" value="$(arg config_yaml)" />
+    </include>
+</launch>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->

--- a/rotors_gazebo/launch/posix_sitl.launch
+++ b/rotors_gazebo/launch/posix_sitl.launch
@@ -1,0 +1,45 @@
+<launch>
+
+    <!-- Posix SITL environment launch script -->
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
+    <arg name="z" default="0"/>
+    <arg name="R" default="0"/>
+    <arg name="P" default="0"/>
+    <arg name="Y" default="0"/>
+    <arg name="est" default="lpe"/>
+    <arg name="vehicle" default="iris"/>
+
+    <arg name="world" default="$(find rotors_gazebo)/worlds/empty.world"/>
+    <arg name="sdf" default="$(find rotors_gazebo)/models/$(arg vehicle)/$(arg vehicle).sdf"/>
+
+    <arg name="rcS" default="$(find px4)/posix-configs/SITL/init/$(arg est)/$(arg vehicle)"/>
+
+    <arg name="headless" default="false"/>
+    <arg name="gui" default="true"/>
+    <arg name="ns" default="/"/>
+
+    <arg name="debug" default="false"/>
+    <arg name="verbose" default="false"/>
+    <arg name="paused" default="false"/>
+
+    <node name="sitl" pkg="px4" type="px4" output="screen"
+        args="$(find px4) $(arg rcS)">
+    </node>
+
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+        <arg name="headless" value="$(arg headless)"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(arg world)" />
+        <arg name="debug" value="$(arg debug)" />
+        <arg name="verbose" value="$(arg verbose)" />
+        <arg name="paused" value="$(arg paused)" />
+    </include>
+
+    <node name="$(anon vehicle_spawn)" output="screen" pkg="gazebo_ros" type="spawn_model"
+        args="-sdf -file $(arg sdf) -model $(arg vehicle) -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg R) -P $(arg P) -Y $(arg Y)"/>
+
+
+</launch>
+
+<!-- vim: set et ft=xml fenc=utf-8 ff=unix sts=0 sw=4 ts=4 : -->

--- a/rotors_gazebo/launch/spawn_mav.launch
+++ b/rotors_gazebo/launch/spawn_mav.launch
@@ -10,13 +10,14 @@
   <arg name="z" default="0.1"/>
   <arg name="enable_logging" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="log_file" default="$(arg mav_name)"/>
   <arg name="wait_to_record_bag" default="false"/>
-  <arg name="enable_mavlink_interface" default="false"/>
+  <arg name="xacro_verbosity" default="1"/>
 
   <!-- send the robot XML to param server -->
   <param name="robot_description" command="
-    $(find xacro)/xacro.py '$(arg model)'
+    $(find xacro)/xacro '$(arg model)' --verbosity $(arg xacro_verbosity) --check-order
     enable_logging:=$(arg enable_logging)
     enable_ground_truth:=$(arg enable_ground_truth)
     enable_mavlink_interface:=$(arg enable_mavlink_interface)
@@ -37,4 +38,16 @@
          -model $(arg namespace)"
    respawn="false" output="screen">
   </node>
+
+  <!-- push robot_description to factory and spawn robot in gazebo -->
+  <node name="sdf_store" pkg="xacro" type="xacro"
+    args="$(arg model) --verbosity $(arg xacro_verbosity) --check-order
+      enable_logging:=$(arg enable_logging)
+      enable_ground_truth:=$(arg enable_ground_truth)
+      enable_mavlink_interface:=$(arg enable_mavlink_interface)
+      log_file:=$(arg log_file)
+      wait_to_record_bag:=$(arg wait_to_record_bag)
+      mav_name:=$(arg mav_name)
+      namespace:=$(arg namespace)"
+    output="screen"/>
 </launch>

--- a/rotors_gazebo/launch/spawn_mav.launch
+++ b/rotors_gazebo/launch/spawn_mav.launch
@@ -39,15 +39,4 @@
    respawn="false" output="screen">
   </node>
 
-  <!-- push robot_description to factory and spawn robot in gazebo -->
-  <node name="sdf_store" pkg="xacro" type="xacro"
-    args="$(arg model) --verbosity $(arg xacro_verbosity) --check-order
-      enable_logging:=$(arg enable_logging)
-      enable_ground_truth:=$(arg enable_ground_truth)
-      enable_mavlink_interface:=$(arg enable_mavlink_interface)
-      log_file:=$(arg log_file)
-      wait_to_record_bag:=$(arg wait_to_record_bag)
-      mav_name:=$(arg mav_name)
-      namespace:=$(arg namespace)"
-    output="screen"/>
 </launch>

--- a/rotors_gazebo/launch/three_multicopters_hovering_example.launch
+++ b/rotors_gazebo/launch/three_multicopters_hovering_example.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="paused" value="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/vi_sensor.launch
+++ b/rotors_gazebo/launch/vi_sensor.launch
@@ -4,8 +4,6 @@
   <arg name="enable_depth" default="true"/>
   <arg name="enable_ground_truth" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -39,7 +39,8 @@
   <run_depend>gazebo_ros</run_depend>
 
   <export>
-    <!--Tell gazebo where to find models, works, and plugins.-->
+    <!--Tell gazebo where to find models(model path),
+         worlds (media path), and plugins (plugin path).-->
     <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}"
       gazebo_model_path="${prefix}/models"/>
   </export>

--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -26,6 +26,7 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>gazebo_ros</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>gazebo_plugins</run_depend>
@@ -35,5 +36,12 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>gazebo_ros</run_depend>
+
+  <export>
+    <!--Tell gazebo where to find models, works, and plugins.-->
+    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}"
+      gazebo_model_path="${prefix}/models"/>
+  </export>
 
 </package>

--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -23,8 +23,8 @@ project(rotors_gazebo_plugins)
 # =============================================================================================== #
 
 if(NOT DEFINED BUILD_MAVLINK_INTERFACE_PLUGIN)
-  message(STATUS "BUILD_MAVLINK_INTERFACE_PLUGIN variable not provided, setting to FALSE.")
-  set(BUILD_MAVLINK_INTERFACE_PLUGIN FALSE)
+  message(STATUS "BUILD_MAVLINK_INTERFACE_PLUGIN variable not provided, setting to TRUE.")
+  set(BUILD_MAVLINK_INTERFACE_PLUGIN TRUE)
 endif()
 
 if(NOT DEFINED BUILD_OCTOMAP_PLUGIN)
@@ -314,6 +314,12 @@ if (BUILD_MAVLINK_INTERFACE_PLUGIN)
     if(EXISTS /opt/ros/indigo/include/mavlink/v1.0/)
       message(STATUS "Found MAVLink headers at '/opt/ros/indigo/include/mavlink/v1.0/'.")
       include_directories("/opt/ros/indigo/include/mavlink/v1.0/")
+      set(MAVLINK_HEADERS_FOUND TRUE)
+    endif()
+
+    if(EXISTS /opt/ros/kinetic/include/mavlink/v1.0/)
+      message(STATUS "Found MAVLink headers at '/opt/ros/kinetic/include/mavlink/v1.0/'.")
+      include_directories("/opt/ros/kinetic/include/mavlink/v1.0/")
       set(MAVLINK_HEADERS_FOUND TRUE)
     endif()
     

--- a/rotors_px4.rosinstall
+++ b/rotors_px4.rosinstall
@@ -16,7 +16,7 @@
     version: indigo-devel
 - git:
     local-name: px4
-    uri: git@github.com:PX4/Firmware
+    uri: https://github.com/PX4/Firmware.git
     version: master
 - git:
     local-name: rotors_simulator

--- a/rotors_px4.rosinstall
+++ b/rotors_px4.rosinstall
@@ -1,0 +1,28 @@
+- git:
+    local-name: catkin_simple
+    uri: https://github.com/catkin/catkin_simple.git
+	version: master
+- git:
+    local-name: mav_comm
+    uri: https://github.com/ethz-asl/mav_comm.git
+	version: master
+- git:
+    local-name: mavlink
+    uri: https://github.com/mavlink/mavlink-gbp-release.git
+    version: upstream
+- git:
+    local-name: mavros
+    uri: https://github.com/mavlink/mavros.git
+    version: indigo-devel
+- git:
+    local-name: px4
+    uri: git@github.com:PX4/Firmware
+	version: master
+- git:
+    local-name: rotors_simulator
+    uri: https://github.com/ethz-asl/rotors_simulator.git
+	version: master
+- git:
+    local-name: yaml_cpp_catkin
+    uri: https://github.com/ethz-asl/yaml_cpp_catkin.git
+	version: master

--- a/rotors_px4.rosinstall
+++ b/rotors_px4.rosinstall
@@ -1,11 +1,11 @@
 - git:
     local-name: catkin_simple
     uri: https://github.com/catkin/catkin_simple.git
-	version: master
+    version: master
 - git:
     local-name: mav_comm
     uri: https://github.com/ethz-asl/mav_comm.git
-	version: master
+    version: master
 - git:
     local-name: mavlink
     uri: https://github.com/mavlink/mavlink-gbp-release.git
@@ -17,12 +17,12 @@
 - git:
     local-name: px4
     uri: git@github.com:PX4/Firmware
-	version: master
+    version: master
 - git:
     local-name: rotors_simulator
-    uri: https://github.com/ethz-asl/rotors_simulator.git
-	version: master
+    uri: https://github.com/jgoppert/rotors_simulator.git
+    version: px4
 - git:
     local-name: yaml_cpp_catkin
     uri: https://github.com/ethz-asl/yaml_cpp_catkin.git
-	version: master
+    version: master


### PR DESCRIPTION
@gbmhunter @devbharat @LorenzMeier 

Let me know what you think of this approach. We don't have to add much to rotors to support px4 sitl, just a few launch scripts.

There are also a few fixes for gazebo_ros paths using export within package.xml.

This works for me. Here is my workspace:

ubuntu 16.04
ros kinetic

```bash
 Localname        S SCM Version (Spec) UID  (Spec)  URI  (Spec) [http(s)://...]
 ---------        - --- -------------- -----------  ---------------------------
 yaml_cpp_catkin    git master         60313a2c8a1c github.com/ethz-asl/yaml_cpp_catkin.git
 rotors_simulator   git px4            2ba519202743 github.com/jgoppert/rotors_simulator.git
 px4                git master         c9643cb0756c git@github.com:PX4/Firmware
 mavros             git indigo-devel   5189e9320db9 github.com/mavlink/mavros.git
 mavlink            git upstream       8c7bc2230c9b github.com/mavlink/mavlink-gbp-release.git
 mav_comm           git master         83d8b322f019 github.com/ethz-asl/mav_comm.git
 catkin_simple      git master         0e62848b12da github.com/catkin/catkin_simple.git
```

I started working on updating the xacro for the mavlink plugin. Once we get that online we can do away with some of our custom launch scripts and use mav.launch etc. The wip here is mav_with_px4.launch

I included a  rotors_px4.rosinstall so you can use that with wstool to bring this environment up.

```bash
mkdir -p ~/catkin
cd ~/catkin
mkdir src
catkin init
catkin config --merge-devel (note the merge-devel is needed to fix a build issue with rotors and newer catkin tools)
cd ~/catkin/src
wstool init
git clone https://github.com/jgoppert/rotors_simulator rotors_simulator
cd ~/catkin/src/rotors_simulator
git checkout -t origin/px4 
cd ~/catkin/src
wstool merge rotors_simulator/rotors_px4.rosinstall
wstool update
cd ~/catkin
catkin build
. ./devel/setup.bash
roslaunch rotors_gazebo mavros_posix_sitl.launch
```