### PR TITLE
Fix to hil_interface.h so to allow build on ROS Kinetic

### DIFF
--- a/rotors_hil_interface/include/rotors_hil_interface/hil_interface.h
+++ b/rotors_hil_interface/include/rotors_hil_interface/hil_interface.h
@@ -19,6 +19,7 @@
 
 #include <mav_msgs/Actuators.h>
 #include <mav_msgs/default_topics.h>
+#include "common/mavlink.h"
 #include <mavros_msgs/HilControls.h>
 #include <mavros_msgs/mavlink_convert.h>
 


### PR DESCRIPTION
Adding this allowed to build the HIL plugin with ROS Kinetic.