### PR TITLE
Fix/dependency

### DIFF
--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -186,7 +186,7 @@ link_libraries(mav_msgs)
 
 if (NOT NO_ROS)
   catkin_package(
-    INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS} ${CATKIN_DEVEL_PREFIX}/include/${PACKAGE_NAME}
+    INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
     LIBRARIES rotors_gazebo_motor_model rotors_gazebo_controller_interface
     CATKIN_DEPENDS cv_bridge geometry_msgs mav_msgs octomap_msgs octomap_ros rosbag roscpp rotors_comm rotors_control std_srvs tf
     DEPENDS eigen gazebo octomap opencv

--- a/rotors_gazebo_plugins/package.xml
+++ b/rotors_gazebo_plugins/package.xml
@@ -34,6 +34,7 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>protobuf-dev</build_depend>
 
 
   <!-- Dependencies needed after this package is compiled. -->


### PR DESCRIPTION
Hopefully this will fix the issue of compiling on ros buildfarm. 

- Remove include file that depends on workspace layout
- Add dependency on protobuf-dev