### PR TITLE
Skip RQT rotors if mavros not found.

### DIFF
--- a/rqt_rotors/CMakeLists.txt
+++ b/rqt_rotors/CMakeLists.txt
@@ -1,6 +1,20 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_rotors)
 
+find_package(mavros_msgs QUIET)
+
+if (mavros_msgs_DIR)
+  message(STATUS "Found mavros_msgs, building ${PROJECT_NAME}.")
+else ()
+  message(STATUS "mavros_msgs not found, skipping ${PROJECT_NAME} package.")
+
+  # We still have to call catkin package for this to be a valid package,
+  # even if empty.
+  find_package(catkin REQUIRED)
+  catkin_package()
+  return()
+endif ()
+
 find_package(catkin REQUIRED COMPONENTS
   mavros_msgs
   rospy


### PR DESCRIPTION
This was breaking mav_integration_test, as mavros is not a requirement for rotors.
If mavros isn't found, this just outputs a status message and doesn't do anything. :) Otherwise builds as normal.