### PR TITLE
added noise to pressure measurement

### DIFF
--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -97,6 +97,7 @@ if (NOT NO_ROS)
     cmake_modules
     cv_bridge
     geometry_msgs
+    glog_catkin
     mav_msgs
     octomap_msgs
     octomap_ros

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_pressure_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_pressure_plugin.h
@@ -17,8 +17,9 @@
 #ifndef ROTORS_GAZEBO_PLUGINS_PRESSURE_PLUGIN_H
 #define ROTORS_GAZEBO_PLUGINS_PRESSURE_PLUGIN_H
 
-// SYSTEM
 #include <random>
+
+#include <glog/logging.h>
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/common.hh>

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_pressure_plugin.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_pressure_plugin.h
@@ -17,6 +17,9 @@
 #ifndef ROTORS_GAZEBO_PLUGINS_PRESSURE_PLUGIN_H
 #define ROTORS_GAZEBO_PLUGINS_PRESSURE_PLUGIN_H
 
+// SYSTEM
+#include <random>
+
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/gazebo.hh>
@@ -51,6 +54,8 @@ class GazeboPressurePlugin : public ModelPlugin {
 
   /// \brief    Destructor.
   virtual ~GazeboPressurePlugin();
+
+  typedef std::normal_distribution<> NormalDistribution;
 
  protected:
   /// \brief    Called when the plugin is first created, and after the world
@@ -104,10 +109,15 @@ class GazeboPressurePlugin : public ModelPlugin {
   /// \brief    Pressure measurement variance (Pa^2).
   double pressure_var_;
 
+  /// \brief    Normal distribution for pressure noise.
+  NormalDistribution pressure_n_[1];
+
   /// \brief    Fluid pressure message.
   /// \details  This is modified everytime OnUpdate() is called,
   //            and then published onto a topic
   gz_sensor_msgs::FluidPressure pressure_message_;
+
+  std::mt19937 random_generator_;
 };
 }
 

--- a/rotors_gazebo_plugins/package.xml
+++ b/rotors_gazebo_plugins/package.xml
@@ -24,6 +24,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>gazebo</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>glog_catkin</build_depend>
   <build_depend>mav_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>octomap_msgs</build_depend>
@@ -36,13 +37,13 @@
   <build_depend>tf</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>protobuf-dev</build_depend>
-  <build_depend>glog_catkin</build_depend>
 
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>cv_bridge</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>glog_catkin</run_depend>
   <run_depend>mav_msgs</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>octomap_msgs</run_depend>
@@ -54,6 +55,5 @@
   <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>yaml-cpp</run_depend>
-  <run_depend>glog_catkin</run_depend>
 
 </package>

--- a/rotors_gazebo_plugins/package.xml
+++ b/rotors_gazebo_plugins/package.xml
@@ -36,6 +36,7 @@
   <build_depend>tf</build_depend>
   <build_depend>yaml-cpp</build_depend>
   <build_depend>protobuf-dev</build_depend>
+  <build_depend>glog_catkin</build_depend>
 
 
   <!-- Dependencies needed after this package is compiled. -->
@@ -53,6 +54,6 @@
   <run_depend>std_srvs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>yaml-cpp</run_depend>
-
+  <run_depend>glog_catkin</run_depend>
 
 </package>

--- a/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
@@ -117,6 +117,9 @@ void GazeboPressurePlugin::OnUpdate(const common::UpdateInfo& _info) {
       kPressureOneAtmospherePascals * exp(kAirConstantDimensionless *
           log(kSeaLevelTempKelvin / temperature_at_altitude_kelvin));
 
+  // Add noise to pressure measurement.
+  pressure_at_altitude_pascal += pressure_n_[0](random_generator_);
+
   // Fill the pressure message.
   pressure_message_.mutable_header()->mutable_stamp()->set_sec(
       current_time.sec);

--- a/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
@@ -76,6 +76,9 @@ void GazeboPressurePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) 
   getSdfParam<double>(_sdf, "referenceAltitude", ref_alt_, kDefaultRefAlt);
   getSdfParam<double>(_sdf, "pressureVariance", pressure_var_, kDefaultPressureVar);
 
+  // Initialize the normal distribution for pressure.
+  pressure_n_[0] = NormalDistribution(0, pressure_var_);
+
   // Listen to the update event. This event is broadcast every simulation
   // iteration.
   this->updateConnection_ = event::Events::ConnectWorldUpdateBegin(

--- a/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
@@ -75,9 +75,11 @@ void GazeboPressurePlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) 
   getSdfParam<std::string>(_sdf, "pressureTopic", pressure_topic_, kDefaultPressurePubTopic);
   getSdfParam<double>(_sdf, "referenceAltitude", ref_alt_, kDefaultRefAlt);
   getSdfParam<double>(_sdf, "pressureVariance", pressure_var_, kDefaultPressureVar);
+  CHECK(pressure_var_ > 0.0);
 
   // Initialize the normal distribution for pressure.
-  pressure_n_[0] = NormalDistribution(0, pressure_var_);
+  double mean = 0.0;
+  pressure_n_[0] = NormalDistribution(mean, sqrt(pressure_var_));
 
   // Listen to the update event. This event is broadcast every simulation
   // iteration.
@@ -121,7 +123,7 @@ void GazeboPressurePlugin::OnUpdate(const common::UpdateInfo& _info) {
           log(kSeaLevelTempKelvin / temperature_at_altitude_kelvin));
 
   // Add noise to pressure measurement.
-  if(pressure_var_ != 0) {
+  if(pressure_var_ > 0.0) {
     pressure_at_altitude_pascal += pressure_n_[0](random_generator_);
   }
 

--- a/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_pressure_plugin.cpp
@@ -121,7 +121,9 @@ void GazeboPressurePlugin::OnUpdate(const common::UpdateInfo& _info) {
           log(kSeaLevelTempKelvin / temperature_at_altitude_kelvin));
 
   // Add noise to pressure measurement.
-  pressure_at_altitude_pascal += pressure_n_[0](random_generator_);
+  if(pressure_var_ != 0) {
+    pressure_at_altitude_pascal += pressure_n_[0](random_generator_);
+  }
 
   // Fill the pressure message.
   pressure_message_.mutable_header()->mutable_stamp()->set_sec(


### PR DESCRIPTION
I noticed that even though you can defined a variance for the pressure sensor. The measurement was not noisy. I fixed that by adding normally distributed noise as it was done for GPS velocity for example.
One problem is now, that for variance = 0 the noise is very small, but not exactly 0. Not sure why that is.. Maybe it would make sense to include an exception for variance = 0 where no noise is added?