### PR TITLE
fix for motors being stuck after gazebo world reset.

### DIFF
--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -14,7 +14,7 @@
 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.M
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
@@ -319,8 +319,10 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   double ref_motor_rot_vel;
   ref_motor_rot_vel =
       rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
-  // Make sure max force is set, as it may be reset to 0 by a world reset any time.
-  // This cannot be done during Reset() because the change will be undone by the Joint's reset function afterwards.
+
+  // Make sure max force is set, as it may be reset to 0 by a world reset any
+  // time. (This cannot be done during Reset() because the change will be undone
+  // by the Joint's reset function afterwards.)
   #if GAZEBO_MAJOR_VERSION < 5
     joint_->SetMaxForce(0, max_force_);
   #endif

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -320,6 +320,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   ref_motor_rot_vel =
       rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
   // Make sure max force is set, as it may be reset to 0 by a world reset any time.
+  // This cannot be done during Reset() because the change will be undone by the Joint's reset function afterwards.
   #if GAZEBO_MAJOR_VERSION < 5
     joint_->SetMaxForce(0, max_force_);
   #endif

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -319,6 +319,10 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   double ref_motor_rot_vel;
   ref_motor_rot_vel =
       rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
+  // make sure max force is still valid, may be reset to 0 by world reset any time.
+  #if GAZEBO_MAJOR_VERSION < 5
+    joint_->SetMaxForce(0, max_force_);
+  #endif
   joint_->SetVelocity(
       0, turning_direction_ * ref_motor_rot_vel / rotor_velocity_slowdown_sim_);
 }

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -319,7 +319,7 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
   double ref_motor_rot_vel;
   ref_motor_rot_vel =
       rotor_velocity_filter_->updateFilter(ref_motor_rot_vel_, sampling_time_);
-  // make sure max force is still valid, may be reset to 0 by world reset any time.
+  // Make sure max force is set, as it may be reset to 0 by a world reset any time.
   #if GAZEBO_MAJOR_VERSION < 5
     joint_->SetMaxForce(0, max_force_);
   #endif


### PR DESCRIPTION
For detailed description see https://github.com/ethz-asl/rotors_simulator/issues/403