### PR TITLE
Fixing GUI element access in rqt_rotors

### DIFF
--- a/rqt_rotors/src/rqt_rotors/hil_plugin.py
+++ b/rqt_rotors/src/rqt_rotors/hil_plugin.py
@@ -124,13 +124,13 @@ class HilPlugin(Plugin):
 
         if (self.armed != msg.armed):
             self.armed = msg.armed
-            self.text_mode_safety_armed.setText(self.mav_mode_text(self.armed))
-            self.button_arm.setEnabled(not(self.armed))
+            self._widget.text_mode_safety_armed.setText(self.mav_mode_text(self.armed))
+            self._widget.button_arm.setEnabled(not(self.armed))
             self.mav_mode = self.mav_mode | self.MAV_MODE_FLAG_SAFETY_ARMED
 
         if (self.guided != msg.guided):
             self.guided = msg.guided
-            self.text_mode_guided.setText(self.mav_mode_text(self.guided))
+            self._widget.text_mode_guided.setText(self.mav_mode_text(self.guided))
 
         self.last_heartbeat_time = time.time()
 


### PR DESCRIPTION
Fixing a small error in the access of GUI elements. The error occurs once the connection with a PX4 is actually established, hence I wasn't able to test this previously.