### PR TITLE
allow negative thrust

### DIFF
--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -259,7 +259,10 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
              "raising the rotor_velocity_slowdown_sim_ param.\n";
   }
   double real_motor_velocity = motor_rot_vel_ * rotor_velocity_slowdown_sim_;
-  double force = real_motor_velocity * real_motor_velocity * motor_constant_;
+  //get the sign of the rotation direction
+  int real_motor_velocity_sign = (real_motor_velocity > 0) - (real_motor_velocity < 0);
+  //assuming symmetric propeller
+  double force = turning_direction_ * real_motor_velocity_sign * real_motor_velocity * real_motor_velocity * motor_constant_;
 
 // TODO(ff): remove this?
 // Code from sitl_gazebo version of GazeboMotorModel.

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -259,9 +259,9 @@ void GazeboMotorModel::UpdateForcesAndMoments() {
              "raising the rotor_velocity_slowdown_sim_ param.\n";
   }
   double real_motor_velocity = motor_rot_vel_ * rotor_velocity_slowdown_sim_;
-  //get the sign of the rotation direction
+  // Get the direction of the rotor rotation.
   int real_motor_velocity_sign = (real_motor_velocity > 0) - (real_motor_velocity < 0);
-  //assuming symmetric propeller
+  //Assuming symmetric propellers (or rotors) for the force calculation.
   double force = turning_direction_ * real_motor_velocity_sign * real_motor_velocity * real_motor_velocity * motor_constant_;
 
 // TODO(ff): remove this?


### PR DESCRIPTION
This change will not affect existing controllers.
If the motor angular velocity cmd is negaive, the thrust direction is
inverted.
For now we assume symmetric prop (3D props), same constants are used for
positive and negative thrusts.