### PR TITLE
Set odometry rate back to 1/1 of real-time rate.

### DIFF
--- a/rotors_description/urdf/mav_generic_odometry_sensor.gazebo
+++ b/rotors_description/urdf/mav_generic_odometry_sensor.gazebo
@@ -36,7 +36,7 @@
     parent_frame_id="world"
     child_frame_id="${namespace}/odometry_sensor1"
     mass_odometry_sensor="0.00001"
-    measurement_divisor="10"
+    measurement_divisor="1"
     measurement_delay="0"
     unknown_delay="0.0"
     noise_normal_position="0 0 0"


### PR DESCRIPTION
Should resolve https://github.com/ethz-asl/rotors_simulator/issues/463
This was my fault, as @aeudes pointed out the real-time rate depends on the world and all of ours have 100 set as the rate, and we were trying to debug issues with a world with presumably a rate of 1000 set.