### PR TITLE
Install libmav_msgs.so

### DIFF
--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -185,6 +185,8 @@ PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${msgs})
 add_library(mav_msgs SHARED ${PROTO_SRCS})
 target_link_libraries(mav_msgs ${PROTOBUF_LIBRARY} gazebo_msgs)
 
+list(APPEND targets_to_install mav_msgs)
+
 # This causes mav_msgs to be linked with every created library in this file from this
 # point forward.
 # NOTE: This is deprecated, should be using target_link_libraries instead


### PR DESCRIPTION
All of the gazebo plugin targets depend on `libmav_msgs.so`. This PR makes sure that library gets installed so the gazebo plugins work from the install space.

Without this PR running `roslaunch rotors_gazebo three_multicopters_hovering_example.launch` with the install space sourced results in:

```
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_multirotor_base_plugin.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_motor_model.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_motor_model.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_motor_model.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_motor_model.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_controller_interface.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_imu_plugin.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_imu_plugin.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_odometry_plugin.so: libmav_msgs.so: cannot open shared object file: No such file or directory
[Err] [Plugin.hh:180] Failed to load plugin librotors_gazebo_odometry_plugin.so: libmav_msgs.so: cannot open shared object 
file: No such file or directory
```