### PR TITLE
Use <gazebo_ros ...> to export paths

### DIFF
--- a/rotors_gazebo/launch/firefly_swarm_hovering_example.launch
+++ b/rotors_gazebo/launch/firefly_swarm_hovering_example.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="mav_name" default="firefly" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/fixed_wing.launch
+++ b/rotors_gazebo/launch/fixed_wing.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/fixed_wing_hil.launch
+++ b/rotors_gazebo/launch/fixed_wing_hil.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/fixed_wing_with_joy.launch
+++ b/rotors_gazebo/launch/fixed_wing_with_joy.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/mav.launch
+++ b/rotors_gazebo/launch/mav.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/mav_hovering_example.launch
+++ b/rotors_gazebo/launch/mav_hovering_example.launch
@@ -11,8 +11,6 @@
       (even when Gazebo is started through roslaunch) -->
   <arg name="verbose" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <arg name="debug" value="$(arg debug)" />

--- a/rotors_gazebo/launch/mav_hovering_example_with_vi_sensor.launch
+++ b/rotors_gazebo/launch/mav_hovering_example_with_vi_sensor.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_powerplant_with_waypoint_publisher.launch
+++ b/rotors_gazebo/launch/mav_powerplant_with_waypoint_publisher.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/powerplant.world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_joy.launch
+++ b/rotors_gazebo/launch/mav_with_joy.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_keyboard.launch
+++ b/rotors_gazebo/launch/mav_with_keyboard.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_waypoint_publisher.launch
+++ b/rotors_gazebo/launch/mav_with_waypoint_publisher.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true" />
   <arg name="log_file" default="$(arg mav_name)" />
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world" />
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/mav_with_wind_gust.launch
+++ b/rotors_gazebo/launch/mav_with_wind_gust.launch
@@ -5,8 +5,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="$(arg mav_name)"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/launch/three_multicopters_hovering_example.launch
+++ b/rotors_gazebo/launch/three_multicopters_hovering_example.launch
@@ -4,8 +4,6 @@
   <arg name="enable_ground_truth" default="true"/>
   <arg name="paused" value="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true"/> -->

--- a/rotors_gazebo/launch/vi_sensor.launch
+++ b/rotors_gazebo/launch/vi_sensor.launch
@@ -4,8 +4,6 @@
   <arg name="enable_depth" default="true"/>
   <arg name="enable_ground_truth" default="false"/>
 
-  <env name="GAZEBO_MODEL_PATH" value="${GAZEBO_MODEL_PATH}:$(find rotors_gazebo)/models"/>
-  <env name="GAZEBO_RESOURCE_PATH" value="${GAZEBO_RESOURCE_PATH}:$(find rotors_gazebo)/models"/>
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="world_name" value="$(find rotors_gazebo)/worlds/$(arg world_name).world"/>
     <!-- <arg name="debug" value="true" /> -->

--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -37,4 +37,8 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
+  <export>
+    <gazebo_ros gazebo_model_path="${prefix}/models"/>
+    <gazebo_ros gazebo_media_path="${prefix}/models"/>
+  </export>
 </package>

--- a/rotors_gazebo_plugins/package.xml
+++ b/rotors_gazebo_plugins/package.xml
@@ -56,4 +56,8 @@
   <run_depend>tf</run_depend>
   <run_depend>yaml-cpp</run_depend>
 
+  <export>
+    <gazebo_ros plugin_path="${prefix}/lib"/>
+  </export>
+
 </package>


### PR DESCRIPTION
This uses the `<export>` section in the `package.xml`to export paths instead of appending to environment variables in the launch file.

This feature comes from [gazebo_ros_paths_plugin](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_ros/src/gazebo_ros_paths_plugin.cpp) which is [included when launching using gazebo_ros](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/905146560772a80f76d9c595b6d7346067de24a1/gazebo_ros/scripts/gazebo#L26).