### PR TITLE
Add eigen dependency.

### DIFF
--- a/rotors_gazebo/CMakeLists.txt
+++ b/rotors_gazebo/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(gazebo REQUIRED)
 
 if(${gazebo_VERSION_MAJOR} GREATER 2)
     message(STATUS "Building iris.sdf.")
-    
+
     set(enable_mavlink_interface "true")
     set(enable_ground_truth "false")
     set(enable_logging "false")
@@ -21,7 +21,7 @@ if(${gazebo_VERSION_MAJOR} GREATER 2)
     set(enable_wind "false")
     set(rotors_description_dir "${CMAKE_CURRENT_SOURCE_DIR}/models/rotors_description")
     set(scripts_dir "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
-    
+
     # Creates shell commands to generate .sdf file
     add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -43,7 +43,10 @@ if(NO_ROS)
   return()
 endif()
 
-find_package(catkin REQUIRED COMPONENTS gazebo_msgs geometry_msgs mav_msgs roscpp sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules gazebo_msgs geometry_msgs mav_msgs roscpp sensor_msgs)
+
+find_package(Eigen REQUIRED)
+include_directories(${EIGEN_INCLUDE_DIRS})
 
 catkin_package(
   CATKIN_DEPENDS

--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -20,6 +20,8 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- Dependencies needed to compile this package. -->
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>gazebo_plugins</build_depend>
   <build_depend>rotors_gazebo_plugins</build_depend>
   <build_depend>mav_msgs</build_depend>
@@ -29,6 +31,7 @@
   <build_depend>sensor_msgs</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
+  <run_depend>eigen</run_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>rotors_gazebo_plugins</run_depend>
   <run_depend>mav_msgs</run_depend>


### PR DESCRIPTION
Fixes
```
/tmp/catkin_workspace_overlay/src/rotors_gazebo/src/hovering_example.cpp:24:22:
fatal error: Eigen/Core: No such file or directory
```

Before it was getting Eigen indirectly from mav_comm but https://github.com/ros/rosdistro/pull/18907 broke it (should be fixed!!).