### PR TITLE
rotors_gazebo/package.xml: alphabetize and add missing run depends

### DIFF
--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -32,9 +32,11 @@
   <run_depend>gazebo_msgs</run_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>joy</run_depend>
   <run_depend>mav_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rotors_gazebo_plugins</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>xacro</run_depend>
 
 </package>

--- a/rotors_gazebo/package.xml
+++ b/rotors_gazebo/package.xml
@@ -20,21 +20,21 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <!-- Dependencies needed to compile this package. -->
-  <build_depend>gazebo_plugins</build_depend>
-  <build_depend>rotors_gazebo_plugins</build_depend>
-  <build_depend>mav_msgs</build_depend>
   <build_depend>gazebo_msgs</build_depend>
+  <build_depend>gazebo_plugins</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>mav_msgs</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>rotors_gazebo_plugins</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
-  <run_depend>gazebo_plugins</run_depend>
-  <run_depend>rotors_gazebo_plugins</run_depend>
-  <run_depend>mav_msgs</run_depend>
   <run_depend>gazebo_msgs</run_depend>
+  <run_depend>gazebo_plugins</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>mav_msgs</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>rotors_gazebo_plugins</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
 </package>


### PR DESCRIPTION
Adds a missing run_depend on `joy` (#501) and `xacro` (part of #500).