### PR TITLE
fix not including message types

### DIFF
--- a/rotors_hil_interface/include/rotors_hil_interface/hil_interface.h
+++ b/rotors_hil_interface/include/rotors_hil_interface/hil_interface.h
@@ -22,6 +22,11 @@
 #include <mavros_msgs/HilControls.h>
 #include <mavros_msgs/mavlink_convert.h>
 
+#ifndef MAVLINK_H
+  typedef mavlink::mavlink_message_t mavlink_message_t;
+  #include <mavlink/v2.0/common/mavlink.h>
+#endif 
+
 #include <rotors_hil_interface/hil_listeners.h>
 
 namespace rotors_hil {


### PR DESCRIPTION
New versions of mavros use mavlink common.hpp rather than common.h. This means that the name of some message types change and the hil interface fails to build.

This fix detects if this is the case and manually includes the needed headers

@kajabo @michaelpantic @maxb91 