### PR TITLE
Update hovering-example instructions for users coming from a vanilla …

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Launch the simulator with a hex-rotor helicopter model, in our case, the AscTec 
 $ roslaunch rotors_gazebo mav_hovering_example.launch mav_name:=firefly world_name:=basic
 ```
 
-> **Note** The first run of gazebo might take considerably long, as it will download some models from an online database.
+> **Note** The first run of gazebo might take considerably long, as it will download some models from an online database. Should you receive a timeout error, try running gazebo by itself (e.g. roslaunch gazebo_ros empty_world.launch ) so it has sufficient time to actually download all of the models.
 
 The simulator starts by default in paused mode. To start it you can either
  - use the Gazebo GUI and press the play button


### PR DESCRIPTION
…installation

This block of code https://github.com/ethz-asl/rotors_simulator/blob/9299985db68cf5894661ec6413a24effef424180/rotors_gazebo/src/hovering_example.cpp#L46-L58 prevents a proper first-time run of the hovering example when the gazebo models haven't been updated yet since it throws a timeout fairly soon. Therefore I added a suggestion to the users to run gazebo once before trying the suggested hovering example.