### PR TITLE
Added wraparound check for angles and error calculation

### DIFF
--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_motor_model.h
@@ -111,7 +111,6 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   virtual void OnUpdate(const common::UpdateInfo & /*_info*/);
 
  private:
-
   /// \brief    Flag that is set to true once CreatePubsAndSubs() is called, used
   ///           to prevent CreatePubsAndSubs() from be called on every OnUpdate().
   bool pubs_and_subs_created_;
@@ -121,6 +120,9 @@ class GazeboMotorModel : public MotorModel, public ModelPlugin {
   ///           be called from Load() because there is no guarantee GazeboRosInterfacePlugin has
   ///           has loaded and listening to ConnectGazeboToRosTopic and ConnectRosToGazeboTopic messages).
   void CreatePubsAndSubs();
+
+  /// \brief    Ensures any input angle is element of [0..2pi)
+  double NormalizeAngle(double input);
 
   std::string command_sub_topic_;
   std::string wind_speed_sub_topic_;

--- a/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_motor_model.cpp
@@ -370,21 +370,21 @@ void GazeboMotorModel::WindSpeedCallback(GzWindSpeedMsgPtr& wind_speed_msg) {
 
 double GazeboMotorModel::NormalizeAngle(double input){
       // Constrain magnitude to be max 2*M_PI.
-      double wraped = std::fmod(std::abs(input), 2*M_PI);
-      wraped = std::copysign(wraped, input);
+      double wrapped = std::fmod(std::abs(input), 2*M_PI);
+      wrapped = std::copysign(wrapped, input);
 
      // Constrain result to be element of [0, 2*pi).
      // Set angle to zero if sufficiently close to 2*pi.
-     if(std::abs(wraped - 2*M_PI) < 1e-8){
-       wraped = 0;
+     if(std::abs(wrapped - 2*M_PI) < 1e-8){
+       wrapped = 0;
      }
 
      // Ensure angle is positive.
-     if(wraped < 0){
-        wraped += 2*M_PI;
+     if(wrapped < 0){
+        wrapped += 2*M_PI;
      }
 
-     return wraped;
+     return wrapped;
 }
 
 void GazeboMotorModel::UpdateForcesAndMoments() {


### PR DESCRIPTION
 - Servo simulation (aka motor plugin with mode = Position) became instable for large steps because wrap-around of position angle and error were not handled.
- is handled now and tested

@ffurrer  Is this anywhere used for linear joints, or is it safe to assume that we're dealing with angles with wrap-around?
