### PR TITLE
Builds with OpenCV4

### DIFF
--- a/rotors_gazebo_plugins/src/external/gazebo_geotagged_images_plugin.cpp
+++ b/rotors_gazebo_plugins/src/external/gazebo_geotagged_images_plugin.cpp
@@ -22,8 +22,6 @@
 #include <iostream>
 
 #include <boost/filesystem.hpp>
-#include <cv.h>
-#include <highgui.h>
 #include <opencv2/opencv.hpp>
 
 #include "rotors_gazebo_plugins/common.h"
@@ -140,7 +138,7 @@ void GeotaggedImagesPlugin::OnNewFrame(const unsigned char * image)
   Mat frame = Mat(height_, width_, CV_8UC3);
   Mat frameBGR = Mat(height_, width_, CV_8UC3);
   frame.data = (uchar*)image; //frame has not the right color format yet -> convert
-  cvtColor(frame, frameBGR, CV_RGB2BGR);
+  cvtColor(frame, frameBGR, cv::COLOR_RGB2BGR);
 
   char file_name[256];
   snprintf(file_name, sizeof(file_name), "%s/DSC%05i.jpg", storageDir_.c_str(), imageCounter_);

--- a/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
@@ -89,7 +89,7 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model,
   if (_sdf->HasElement("covarianceImage")) {
     std::string image_name =
         _sdf->GetElement("covarianceImage")->Get<std::string>();
-    covariance_image_ = cv::imread(image_name, CV_LOAD_IMAGE_GRAYSCALE);
+    covariance_image_ = cv::imread(image_name, cv::IMREAD_GRAYSCALE);
     if (covariance_image_.data == NULL)
       gzerr << "loading covariance image " << image_name << " failed"
             << std::endl;


### PR DESCRIPTION
This PR removes references to the (deprecated) OpenCV C API and allows RotorS to build on OpenCV 4 as well as previous versions. 