### PR TITLE
Add support for ROS Noetic

### DIFF
--- a/rotors_demos.rosinstall
+++ b/rotors_demos.rosinstall
@@ -1,5 +1,4 @@
 - git: {local-name: asctec_mav_framework, uri: 'https://github.com/ethz-asl/asctec_mav_framework.git'}
 - git: {local-name: ethzasl_msf, uri: 'https://github.com/ethz-asl/ethzasl_msf.git'}
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
-- git: {local-name: rotors_simulator, uri: 'https://github.com/ethz-asl/rotors_simulator.git'}
 - git: {local-name: rotors_simulator_demos, uri: 'https://github.com/ethz-asl/rotors_simulator_demos.git'}

--- a/rotors_gazebo/CMakeLists.txt
+++ b/rotors_gazebo/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions(-std=c++11)
 # We need Gazebo version >= 3.0.0 to generate iris.sdf file
 # (gz sdf ... command needs to be available)
 find_package(gazebo REQUIRED)
+find_package(PythonInterp REQUIRED)
 
 if(${gazebo_VERSION_MAJOR} GREATER 2)
     message(STATUS "Building iris.sdf.")
@@ -26,7 +27,7 @@ if(${gazebo_VERSION_MAJOR} GREATER 2)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND rm -f ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
-      COMMAND python ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
+      COMMAND ${PYTHON_EXECUTABLE} ${scripts_dir}/xacro.py -o  ${rotors_description_dir}/urdf/iris_base.urdf  ${rotors_description_dir}/urdf/iris_base.xacro enable_mavlink_interface:=${enable_mavlink_interface} enable_ground_truth:=${enable_ground_truth} enable_wind:=${enable_wind} enable_logging:=${enable_logging} rotors_description_dir:=${rotors_description_dir}
       COMMAND gz sdf -p  ${rotors_description_dir}/urdf/iris_base.urdf >> ${CMAKE_CURRENT_SOURCE_DIR}/models/iris/iris.sdf
       COMMAND rm -f ${rotors_description_dir}/urdf/iris_base.urdf
       DEPENDS ${rotors_description_dir}/urdf/iris.xacro

--- a/rotors_hil.rosinstall
+++ b/rotors_hil.rosinstall
@@ -1,3 +1,2 @@
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
 - git: {local-name: mavlink, uri: 'https://github.com/mavlink/mavlink-gbp-release.git', version: 'upstream'}
-- git: {local-name: rotors_simulator, uri: 'https://github.com/ethz-asl/rotors_simulator.git'}

--- a/rotors_minimal.rosinstall
+++ b/rotors_minimal.rosinstall
@@ -1,2 +1,1 @@
 - git: {local-name: mav_comm, uri: 'https://github.com/ethz-asl/mav_comm.git'}
-- git: {local-name: rotors_simulator, uri: 'https://github.com/ethz-asl/rotors_simulator.git'}


### PR DESCRIPTION
**Problem Description**
Since ROS Noetic only supports Ubuntu Focal(20.04) and python2 is not shipped with it, we need to move towards using python3 in order to support ROS Noetic

**Solution**
This uses `PythonInterp` in the CMakeLists in order to figure out which python version is available in the system

In order to verify that it works, I have added a github actions pipeline to test the builds in the following ROS distributions
- ROS Noetic on Ubuntu Focal
- ROS Melodic on Ubuntu Bionic
- ROS Kinetic on Ubuntu Xenial 

Also to automate the pipeline a bit better, I have removed self referencing it's dependencies in the `rosinstall` file

**Additional Context**
- This still doesn't solve the issue that python2 is being used in various places in this repo, but I believe that needs to be done with more care and should belong to a separate PR