### PR TITLE
Use predefined constant Pi

### DIFF
--- a/rotors_description/urdf/component_snippets.xacro
+++ b/rotors_description/urdf/component_snippets.xacro
@@ -20,7 +20,6 @@
 -->
 
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:property name="pi" value="3.14159265359" />
 
   <!-- Macro to add logging to a bag file. -->
   <xacro:macro name="bag_plugin_macro"


### PR DESCRIPTION
Basic constants are predefined, so no need to define our own `PI`.
* this gets rid of the yellow warning during start-up: `redefining global symbol: pi`
* some more info [here](https://answers.ros.org/question/277011/using-pi-in-an-urdf-file/)

