### PR TITLE
Changing the C++ Standard Version to C++17

### DIFF
--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -91,7 +91,7 @@ else()
 endif()
 
 # Specify C++11 standard
-add_definitions(-std=c++11)
+add_definitions(-std=c++17)
 
 # Provides a compiler flag notifying the preprocessor about
 # the MAVLink Interface plugin build status


### PR DESCRIPTION
We had the C++ Standard version set to C++11 resulting in errors in almost all the systems on which we were building this package. Thus, I've made the necessary changes. 

Its a pretty big error which is difficult to find out otherwise.